### PR TITLE
Implement LLM Foundations and Announcement Summaries

### DIFF
--- a/CanvasPlusPlayground.xcodeproj/project.pbxproj
+++ b/CanvasPlusPlayground.xcodeproj/project.pbxproj
@@ -45,6 +45,12 @@
 		B76455092C8DF61B002DF00E /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B76454F22C8DF61B002DF00E /* Preview Assets.xcassets */; };
 		B764550A2C8DF61B002DF00E /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B76454F92C8DF61B002DF00E /* Assets.xcassets */; };
 		B7A26EE92CCB62A30084704A /* NavigationModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7A26EE82CCB62A00084704A /* NavigationModel.swift */; };
+		B7AD54F32CD41D7900FB09BB /* LLMEvaluator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7AD54F12CD41D7900FB09BB /* LLMEvaluator.swift */; };
+		B7AD54F42CD41D7900FB09BB /* Models.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7AD54F22CD41D7900FB09BB /* Models.swift */; };
+		B7AD54F52CD41D7900FB09BB /* Data.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7AD54EF2CD41D7900FB09BB /* Data.swift */; };
+		B7AD54F62CD41D7900FB09BB /* DeviceStat.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7AD54F02CD41D7900FB09BB /* DeviceStat.swift */; };
+		B7AD550A2CD4250700FB09BB /* LLM in Frameworks */ = {isa = PBXBuildFile; productRef = B7AD55092CD4250700FB09BB /* LLM */; };
+		B7AD550C2CD4257B00FB09BB /* IntelligenceOnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7AD550B2CD4257400FB09BB /* IntelligenceOnboardingView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -87,6 +93,11 @@
 		B76454FB2C8DF61B002DF00E /* CourseFileManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseFileManager.swift; sourceTree = "<group>"; };
 		B76454FC2C8DF61B002DF00E /* CourseManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseManager.swift; sourceTree = "<group>"; };
 		B7A26EE82CCB62A00084704A /* NavigationModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationModel.swift; sourceTree = "<group>"; };
+		B7AD54EF2CD41D7900FB09BB /* Data.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Data.swift; sourceTree = "<group>"; };
+		B7AD54F02CD41D7900FB09BB /* DeviceStat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceStat.swift; sourceTree = "<group>"; };
+		B7AD54F12CD41D7900FB09BB /* LLMEvaluator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LLMEvaluator.swift; sourceTree = "<group>"; };
+		B7AD54F22CD41D7900FB09BB /* Models.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Models.swift; sourceTree = "<group>"; };
+		B7AD550B2CD4257400FB09BB /* IntelligenceOnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntelligenceOnboardingView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -94,6 +105,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B7AD550A2CD4250700FB09BB /* LLM in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -138,6 +150,7 @@
 		B76454F12C8DF61B002DF00E /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				B7AD54EE2CD41D5200FB09BB /* Intelligence */,
 				B76454ED2C8DF61B002DF00E /* Course.swift */,
 				B76454EE2C8DF61B002DF00E /* Enrollment.swift */,
 				B76454EF2C8DF61B002DF00E /* File.swift */,
@@ -160,6 +173,7 @@
 		B76454F82C8DF61B002DF00E /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				B7AD550B2CD4257400FB09BB /* IntelligenceOnboardingView.swift */,
 				3DAE84FD2C9A0CE8008C22E7 /* CoursePDFView.swift */,
 				B76454F42C8DF61B002DF00E /* CourseFilesView.swift */,
 				9B6663E22C9853BC0060990E /* AsyncAttributedText.swift */,
@@ -201,6 +215,17 @@
 			path = CanvasPlusPlayground;
 			sourceTree = "<group>";
 		};
+		B7AD54EE2CD41D5200FB09BB /* Intelligence */ = {
+			isa = PBXGroup;
+			children = (
+				B7AD54EF2CD41D7900FB09BB /* Data.swift */,
+				B7AD54F02CD41D7900FB09BB /* DeviceStat.swift */,
+				B7AD54F12CD41D7900FB09BB /* LLMEvaluator.swift */,
+				B7AD54F22CD41D7900FB09BB /* Models.swift */,
+			);
+			path = Intelligence;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -218,6 +243,7 @@
 			);
 			name = CanvasPlusPlayground;
 			packageProductDependencies = (
+				B7AD55092CD4250700FB09BB /* LLM */,
 			);
 			productName = CanvasPlusPlayground;
 			productReference = B76454642C8BBC7F002DF00E /* CanvasPlusPlayground.app */;
@@ -249,6 +275,7 @@
 			mainGroup = B764545B2C8BBC7F002DF00E;
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
+				B7AD55082CD4250700FB09BB /* XCRemoteSwiftPackageReference "mlx-swift-examples" */,
 			);
 			productRefGroup = B76454652C8BBC7F002DF00E /* Products */;
 			projectDirPath = "";
@@ -295,6 +322,10 @@
 				B76455042C8DF61B002DF00E /* CourseView.swift in Sources */,
 				9B92A4252C93856100C21CFC /* CourseAnnouncementManager.swift in Sources */,
 				B76455052C8DF61B002DF00E /* SetupView.swift in Sources */,
+				B7AD54F32CD41D7900FB09BB /* LLMEvaluator.swift in Sources */,
+				B7AD54F42CD41D7900FB09BB /* Models.swift in Sources */,
+				B7AD54F52CD41D7900FB09BB /* Data.swift in Sources */,
+				B7AD54F62CD41D7900FB09BB /* DeviceStat.swift in Sources */,
 				9B350F082C9652C6003FC60D /* NSAttributedString+HTML.swift in Sources */,
 				9B9C2E042C93F6CD00E4B16B /* CourseAnnouncementsView.swift in Sources */,
 				192EC04C2C963EE600AF8528 /* CourseAssignmentView.swift in Sources */,
@@ -311,6 +342,7 @@
 				B76455082C8DF61B002DF00E /* CourseManager.swift in Sources */,
 				9B9C2E062C93F94C00E4B16B /* CourseAnnouncementDetailView.swift in Sources */,
 				9B6663E32C9853BC0060990E /* AsyncAttributedText.swift in Sources */,
+				B7AD550C2CD4257B00FB09BB /* IntelligenceOnboardingView.swift in Sources */,
 				7F8535742C98DE3C0023E384 /* CourseGradeView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -527,6 +559,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		B7AD55082CD4250700FB09BB /* XCRemoteSwiftPackageReference "mlx-swift-examples" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/ml-explore/mlx-swift-examples/";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.16.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		B7AD55092CD4250700FB09BB /* LLM */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B7AD55082CD4250700FB09BB /* XCRemoteSwiftPackageReference "mlx-swift-examples" */;
+			productName = LLM;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = B764545C2C8BBC7F002DF00E /* Project object */;
 }

--- a/CanvasPlusPlayground/CanvasPlusPlaygroundApp.swift
+++ b/CanvasPlusPlayground/CanvasPlusPlaygroundApp.swift
@@ -10,11 +10,15 @@ import SwiftUI
 @main
 struct CanvasPlusPlaygroundApp: App {
     @State private var courseManager = CourseManager()
+    @StateObject private var intelligenceManager = IntelligenceManager()
+    @StateObject private var llmEvaluator = LLMEvaluator()
 
     var body: some Scene {
         WindowGroup {
             CourseListView()
                 .environment(CourseManager())
+                .environmentObject(IntelligenceManager())
+                .environmentObject(LLMEvaluator())
         }
     }
 }

--- a/CanvasPlusPlayground/Helpers/NavigationModel.swift
+++ b/CanvasPlusPlayground/Helpers/NavigationModel.swift
@@ -17,4 +17,6 @@ class NavigationModel {
         didSet { selectedCoursePage = nil }
     }
     var selectedCoursePage: CoursePage?
+
+    var showInstallIntelligenceSheet = false
 }

--- a/CanvasPlusPlayground/Model/Intelligence/Data.swift
+++ b/CanvasPlusPlayground/Model/Intelligence/Data.swift
@@ -1,0 +1,91 @@
+/*
+ Imported from fullmoon app: https://github.com/mainframecomputer/fullmoon-ios
+ */
+
+import SwiftUI
+import SwiftData
+
+class IntelligenceManager: ObservableObject {
+    @AppStorage("systemPrompt") var systemPrompt = "you are a helpful assistant"
+    @AppStorage("currentModelName") var currentModelName: String?
+        
+    private let installedModelsKey = "installedModels"
+        
+    @Published var installedModels: [String] = [] {
+        didSet {
+            saveInstalledModelsToUserDefaults()
+        }
+    }
+    
+    init() {
+        loadInstalledModelsFromUserDefaults()
+    }
+        
+    // Function to save the array to UserDefaults as JSON
+    private func saveInstalledModelsToUserDefaults() {
+        if let jsonData = try? JSONEncoder().encode(installedModels) {
+            UserDefaults.standard.set(jsonData, forKey: installedModelsKey)
+        }
+    }
+    
+    // Function to load the array from UserDefaults
+    private func loadInstalledModelsFromUserDefaults() {
+        if let jsonData = UserDefaults.standard.data(forKey: installedModelsKey),
+           let decodedArray = try? JSONDecoder().decode([String].self, from: jsonData) {
+            self.installedModels = decodedArray
+        } else {
+            self.installedModels = [] // Default to an empty array if there's no data
+        }
+    }
+    
+    func addInstalledModel(_ model: String) {
+        if !installedModels.contains(model) {
+            installedModels.append(model)
+        }
+    }
+    
+    func modelDisplayName(_ modelName: String) -> String {
+        return modelName.replacingOccurrences(of: "mlx-community/", with: "").lowercased()
+    }
+}
+
+enum Role: String, Codable {
+    case assistant
+    case user
+    case system
+}
+
+class Message {
+    var id: UUID
+    var role: Role
+    var content: String
+    var timestamp: Date
+    
+    var thread: Thread?
+    
+    init(role: Role, content: String, thread: Thread? = nil) {
+        self.id = UUID()
+        self.role = role
+        self.content = content
+        self.timestamp = Date()
+        self.thread = thread
+    }
+}
+
+
+class Thread {
+    var id: UUID
+    var title: String?
+    var timestamp: Date
+    
+    var messages: [Message] = []
+    
+    var sortedMessages: [Message] {
+        return messages.sorted { $0.timestamp < $1.timestamp }
+    }
+    
+    init() {
+        self.id = UUID()
+        self.timestamp = Date()
+    }
+}

--- a/CanvasPlusPlayground/Model/Intelligence/DeviceStat.swift
+++ b/CanvasPlusPlayground/Model/Intelligence/DeviceStat.swift
@@ -1,0 +1,35 @@
+/*
+ Imported from fullmoon app: https://github.com/mainframecomputer/fullmoon-ios
+ */
+
+import Foundation
+import MLXLLM
+import MLX
+
+@Observable
+final class DeviceStat: @unchecked Sendable {
+
+    @MainActor
+    var gpuUsage = GPU.snapshot()
+
+    private let initialGPUSnapshot = GPU.snapshot()
+    private var timer: Timer?
+
+    init() {
+        timer = Timer.scheduledTimer(withTimeInterval: 2.0, repeats: true) { [weak self] _ in
+            self?.updateGPUUsages()
+        }
+    }
+
+    deinit {
+        timer?.invalidate()
+    }
+
+    private func updateGPUUsages() {
+        let gpuSnapshotDelta = initialGPUSnapshot.delta(GPU.snapshot())
+        DispatchQueue.main.async { [weak self] in
+            self?.gpuUsage = gpuSnapshotDelta
+        }
+    }
+
+}

--- a/CanvasPlusPlayground/Model/Intelligence/LLMEvaluator.swift
+++ b/CanvasPlusPlayground/Model/Intelligence/LLMEvaluator.swift
@@ -1,0 +1,141 @@
+/*
+ Imported from fullmoon app: https://github.com/mainframecomputer/fullmoon-ios
+ */
+
+import MLX
+import MLXLLM
+import MLXRandom
+import SwiftUI
+
+@Observable
+@MainActor
+class LLMEvaluator: ObservableObject {
+    var running = false
+    var output = ""
+    var modelInfo = ""
+    var stat = ""
+    var progress = 0.0
+
+    var modelConfiguration = ModelConfiguration.defaultModel
+    
+    func switchModel(_ model: ModelConfiguration) async {
+        progress = 0.0 // reset progress
+        loadState = .idle
+        modelConfiguration = model
+        _ = try? await load(modelName: model.name)
+    }
+
+    /// parameters controlling the output
+    let generateParameters = GenerateParameters(temperature: 0.5)
+    let maxTokens = 4096
+
+    /// update the display every N tokens -- 4 looks like it updates continuously
+    /// and is low overhead.  observed ~15% reduction in tokens/s when updating
+    /// on every token
+    let displayEveryNTokens = 4
+
+    enum LoadState {
+        case idle
+        case loaded(ModelContainer)
+    }
+
+    var loadState = LoadState.idle
+
+    /// load and return the model -- can be called multiple times, subsequent calls will
+    /// just return the loaded model
+    private func load(modelName: String) async throws -> ModelContainer {
+        let model = getModelByName(modelName)
+        
+        switch loadState {
+        case .idle:
+            // limit the buffer cache
+            MLX.GPU.set(cacheLimit: 20 * 1024 * 1024)
+
+            let modelContainer = try await MLXLLM.loadModelContainer(configuration: model!)
+            {
+                [modelConfiguration] progress in
+                Task { @MainActor in
+                    self.modelInfo =
+                        "Downloading \(modelConfiguration.name): \(Int(progress.fractionCompleted * 100))%"
+                    self.progress = progress.fractionCompleted
+                }
+            }
+            self.modelInfo =
+                "Loaded \(modelConfiguration.id).  Weights: \(MLX.GPU.activeMemory / 1024 / 1024)M"
+            loadState = .loaded(modelContainer)
+            return modelContainer
+
+        case .loaded(let modelContainer):
+            return modelContainer
+        }
+    }
+
+    func generate(modelName: String, message: String, systemPrompt: String) async -> String {
+        guard !running else { return "" }
+
+        running = true
+        self.output = ""
+
+        do {
+            let modelContainer = try await load(modelName: modelName)
+            let extraEOSTokens = modelConfiguration.extraEOSTokens
+
+            // augment the prompt as needed
+            let thread = Thread()
+            thread.messages.append(.init(role: .user, content: message))
+            let promptHistory = modelConfiguration.getPromptHistory(
+                thread: thread,
+                systemPrompt: systemPrompt
+            )
+            let prompt = modelConfiguration.prepare(prompt: promptHistory)
+
+            let promptTokens = await modelContainer.perform { _, tokenizer in
+                tokenizer.encode(text: prompt)
+            }
+
+            // each time you generate you will get something new
+            MLXRandom.seed(UInt64(Date.timeIntervalSinceReferenceDate * 1000))
+
+            let result = await modelContainer.perform { model, tokenizer in
+                MLXLLM.generate(
+                    promptTokens: promptTokens, parameters: generateParameters, model: model,
+                    tokenizer: tokenizer, extraEOSTokens: extraEOSTokens
+                ) { tokens in
+                    // update the output -- this will make the view show the text as it generates
+                    if tokens.count % displayEveryNTokens == 0 {
+                        let text = tokenizer.decode(tokens: tokens)
+                        Task { @MainActor in
+                            self.output = text
+                        }
+                    }
+
+                    if tokens.count >= maxTokens {
+                        return .stop
+                    } else {
+                        return .more
+                    }
+                }
+            }
+
+            // update the text if needed, e.g. we haven't displayed because of displayEveryNTokens
+            if result.output != self.output {
+                self.output = result.output
+            }
+            self.stat = " Tokens/second: \(String(format: "%.3f", result.tokensPerSecond))"
+
+        } catch {
+            output = "Failed: \(error)"
+        }
+
+        running = false
+        return output
+    }
+    
+    func getModelByName(_ name: String) -> ModelConfiguration? {
+        if let model = ModelConfiguration.availableModels.first(where: { $0.name == name }) {
+            return model
+        } else {
+            return nil
+        }
+    }
+}

--- a/CanvasPlusPlayground/Model/Intelligence/Models.swift
+++ b/CanvasPlusPlayground/Model/Intelligence/Models.swift
@@ -1,0 +1,53 @@
+/*
+ Imported from fullmoon app: https://github.com/mainframecomputer/fullmoon-ios
+ */
+
+import MLXLLM
+import Foundation
+
+extension ModelConfiguration: @retroactive Equatable {
+    public static func == (lhs: MLXLLM.ModelConfiguration, rhs: MLXLLM.ModelConfiguration) -> Bool {
+        return lhs.name == rhs.name
+    }
+    
+    public static let llama_3_2_1B_4bit = ModelConfiguration(
+        id: "mlx-community/Llama-3.2-1B-Instruct-4bit"
+    )
+    
+    public static let llama_3_2_3b_4bit = ModelConfiguration(
+        id: "mlx-community/Llama-3.2-3B-Instruct-4bit"
+    )
+    
+    public static var availableModels: [ModelConfiguration] = [
+        llama_3_2_1B_4bit,
+        llama_3_2_3b_4bit
+    ]
+    
+    public static var defaultModel: ModelConfiguration {
+        llama_3_2_1B_4bit
+    }
+    
+    func getPromptHistory(thread: Thread, systemPrompt: String) -> String {
+        var history = ""
+        
+        switch self {
+        case .llama_3_2_1B_4bit, .llama_3_2_3b_4bit:
+            history = "<|begin_of_text|>"
+            history += "<|start_header_id|>system<|end_header_id|>\n\(systemPrompt)"
+            
+            for message in thread.sortedMessages {
+                print(message.content)
+                if message.role == .user {
+                    history += "<|eot_id|>\n<|start_header_id|>user<|end_header_id|>\n\(message.content)\n<|eot_id|>\n<|start_header_id|>assistant<|end_header_id|>"
+                }
+                
+                if message.role == .assistant {
+                    history += message.content + "\n"
+                }
+            }
+        default:
+            break;
+        }
+        return history
+    }
+}

--- a/CanvasPlusPlayground/Views/IntelligenceOnboardingView.swift
+++ b/CanvasPlusPlayground/Views/IntelligenceOnboardingView.swift
@@ -1,0 +1,199 @@
+//
+//  IntelligenceOnboardingView.swift
+//  CanvasPlusPlayground
+//
+//  Created by Rahul on 10/31/24.
+//
+
+import SwiftUI
+import MLXLLM
+
+struct IntelligenceOnboardingView: View {
+    enum InstallState {
+        case selectModel
+        case installing
+        case installed
+    }
+
+    @Environment(\.dismiss) private var dismiss
+    @EnvironmentObject private var intelligenceManager: IntelligenceManager
+    @EnvironmentObject private var llmEvaluator: LLMEvaluator
+
+    @State private var selectedModel: ModelConfiguration?
+    @State private var currentInstallState: InstallState = .selectModel
+
+    var body: some View {
+        VStack(spacing: 8) {
+            Spacer()
+
+            header
+
+            Spacer()
+
+            List {
+                listContent
+            }
+            .listStyle(.plain)
+
+            Spacer()
+
+            if currentInstallState == .installing {
+                HStack {
+                    ProgressView(value: llmEvaluator.progress, total: 1)
+                        .progressViewStyle(.linear)
+                    ProgressView()
+                }
+            }
+        }
+        .fontDesign(.rounded)
+        .padding()
+        .onChange(of: llmEvaluator.progress) { oldValue, newValue in
+            if newValue == 1.0 {
+                completeInstallation()
+            }
+        }
+        .toolbar {
+            if currentInstallState == .selectModel {
+                #if os(macOS)
+                ToolbarItem(placement: .destructiveAction) {
+                    Button("Cancel") {
+                        dismiss()
+                    }
+                }
+                #else
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel", systemImage: "xmark.circle.fill") {
+                        dismiss()
+                    }
+                    .labelsHidden()
+                }
+                #endif
+
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Install") {
+                        installModel()
+                    }
+                    .disabled(selectedModel == nil)
+                }
+            } else if currentInstallState == .installed {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") {
+                        dismiss()
+                    }
+                }
+            }
+        }
+        #if os(macOS)
+        .frame(minHeight: 400)
+        #endif
+    }
+
+    @ViewBuilder
+    private var header: some View {
+        Image(systemName: "wand.and.stars")
+            .font(.largeTitle)
+            .foregroundStyle(.tint)
+
+        Text("Install a Model")
+            .font(.largeTitle)
+            .bold()
+
+        Text(descriptionText)
+            .multilineTextAlignment(.center)
+    }
+
+    @ViewBuilder
+    private var listContent: some View {
+        Section("Available") {
+            ForEach(filteredModels, id: \.name) { model in
+                Button {
+                    selectedModel = model
+                } label: {
+                    HStack {
+                        Text(intelligenceManager.modelDisplayName(model.name))
+                        Spacer()
+                        if selectedModel == model {
+                            Image(systemName: "checkmark")
+                        }
+                    }
+                    .contentShape(.rect)
+                }
+            }
+        }
+        .disabled(currentInstallState != .selectModel)
+
+        if !intelligenceManager.installedModels.isEmpty {
+            Section("Installed") {
+                ForEach(intelligenceManager.installedModels, id: \.self) { model in
+                    Button {
+                        if let config = llmEvaluator.getModelByName(model) {
+                            selectedModel = config
+                            installModel()
+                        }
+                    } label: {
+                        HStack {
+                            Text(model)
+                            Spacer()
+                            if intelligenceManager.currentModelName == model {
+                                Image(systemName: "checkmark")
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private func installModel() {
+        #if os(iOS)
+        UIApplication.shared.isIdleTimerDisabled = true
+        #endif
+
+        Task {
+            if let selectedModel {
+                currentInstallState = .installing
+                await llmEvaluator.switchModel(selectedModel)
+            }
+        }
+    }
+
+    private func completeInstallation() {
+        #if os(iOS)
+        UIApplication.shared.isIdleTimerDisabled = false
+        #endif
+
+        if let selectedModel {
+            intelligenceManager.currentModelName = selectedModel.name
+            intelligenceManager.addInstalledModel(selectedModel.name)
+        }
+
+        currentInstallState = .installed
+    }
+
+    private var filteredModels: [ModelConfiguration] {
+        ModelConfiguration.availableModels
+            .filter { !intelligenceManager.installedModels.contains($0.name) }
+            .sorted { $0.name < $1.name }
+    }
+
+    private var descriptionText: String {
+        let modelName = intelligenceManager.modelDisplayName(selectedModel?.name ?? "")
+
+        return switch currentInstallState {
+        case .selectModel:
+            "Choose a model to install and use for summarization and other intelligence features."
+        case .installing:
+            "Installing \(modelName)"
+        case .installed:
+            "Installed \(modelName)"
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        IntelligenceOnboardingView()
+    }
+        .environmentObject(IntelligenceManager())
+        .environmentObject(LLMEvaluator())
+}


### PR DESCRIPTION
Uses MLXSwift and foundational code from https://github.com/mainframecomputer/fullmoon-ios to introduce the following features:
- Download from a selection of LLM models to run locally on-device.
- Switch between LLMs to use for intelligence features.
- Implement the ability to summarize an announcement message using the downloaded LLM.

This code also refactors the announcement detail view.

Code may be better refactored and cleaned up in the future, but this is a good start.


https://github.com/user-attachments/assets/9baafa9b-9df3-426f-8f6e-bdaf8e502931

<img width="544.5" alt="Screenshot 2024-11-01 at 11 36 34 AM" src="https://github.com/user-attachments/assets/d8b6aa9c-5bfb-40c7-b092-28b7a5550706">
<img width="544.5" alt="Screenshot 2024-11-01 at 11 36 32 AM" src="https://github.com/user-attachments/assets/434b57e4-33e4-456b-945c-f261e31cce33">
