### PR TITLE
Cache Announcement Summaries

### DIFF
--- a/CanvasPlusPlayground/Model/Announcement.swift
+++ b/CanvasPlusPlayground/Model/Announcement.swift
@@ -16,9 +16,11 @@ final class Announcement: Cacheable {
     var title:String?
     var createdAt:Date?
     var message:String?
-    
+
+    // MARK: Custom Properties
     var isRead: Bool?
-    
+    var summary: String?
+
     weak var course: Course?
     var parentId: String?
     

--- a/CanvasPlusPlayground/Views/CourseAnnouncementDetailView.swift
+++ b/CanvasPlusPlayground/Views/CourseAnnouncementDetailView.swift
@@ -11,7 +11,6 @@ struct CourseAnnouncementDetailView: View {
     @EnvironmentObject private var llmEvaluator: LLMEvaluator
     @EnvironmentObject private var intelligenceManager: IntelligenceManager
 
-    @State private var announcementSummary: String?
     @State private var loadingSummary = false
 
     let announcement: Announcement
@@ -57,7 +56,7 @@ struct CourseAnnouncementDetailView: View {
 
     private var summarySection: some View {
         Group {
-            if let announcementSummary {
+            if let announcementSummary = announcement.summary {
                 Text(announcementSummary)
             } else {
                 HStack {
@@ -94,7 +93,7 @@ struct CourseAnnouncementDetailView: View {
         """
 
         if let modelName = intelligenceManager.currentModelName {
-            announcementSummary = await llmEvaluator
+            announcement.summary = await llmEvaluator
                 .generate(
                     modelName: modelName,
                     message: prompt,

--- a/CanvasPlusPlayground/Views/CourseAnnouncementsView.swift
+++ b/CanvasPlusPlayground/Views/CourseAnnouncementsView.swift
@@ -28,8 +28,11 @@ struct CourseAnnouncementsView: View {
                     HStack {
                         Text(announcment.title ?? "")
                         Spacer()
-                        Text(announcment.isRead == true ? "Read" : "Unread")
-                            .foregroundStyle(.blue)
+                        if !(announcment.isRead ?? false) {
+                            Circle()
+                                .fill(.tint)
+                                .frame(width: 10, height: 10)
+                        }
                     }
                 }
             }


### PR DESCRIPTION
- Caches announcement summaries
- Adds ability to summarize announcements again, even after summary is available.
- Changes unread announcement indicator to circle 'dot'.

<img width="1139" alt="image" src="https://github.com/user-attachments/assets/64ca40d7-12fd-46ad-a040-148bd627c8fc">
