### PR TITLE
Service Layer Cleanup

### DIFF
--- a/CanvasPlusPlayground/CourseAnnouncementManager.swift
+++ b/CanvasPlusPlayground/CourseAnnouncementManager.swift
@@ -18,7 +18,7 @@ import Foundation
     }
     
     func fetchAnnouncements() async {
-        let announcements: [Announcement]? = try? await CanvasService.shared.defaultAndFetch(
+        let announcements: ([Announcement], [Announcement].Type)? = try? await CanvasService.shared.defaultAndFetch(
             .getAnnouncements(courseId: courseId),
             onCacheReceive: { (cached: [Announcement]?) in
                 guard let cached else { return }
@@ -42,7 +42,7 @@ import Foundation
             return
         }
         
-        self.announcements = announcements
+        self.announcements = announcements.0
         
     }
 }

--- a/CanvasPlusPlayground/CourseManager.swift
+++ b/CanvasPlusPlayground/CourseManager.swift
@@ -23,7 +23,7 @@ class CourseManager {
 
     func getCourses() async {
         do {
-            let courses: [Course] = try await CanvasService.shared.defaultAndFetch(
+            let (courses, _): ([Course], [Course].Type) = try await CanvasService.shared.defaultAndFetch(
                 .getCourses(enrollmentState: "active"),
                 onCacheReceive: { cachedCourses in
                    guard let cachedCourses else { return }


### PR DESCRIPTION
Because of generics, my prev implementation wasn't exactly type-safe. Now it is. One caveat though which is that the return type is tuple.

This is because of the limitation that a provided generic T must be mentioned in the function header directly (T.Element doesn't count)