### PR TITLE
People Backtrack: Display cached results while performing network call

### DIFF
--- a/CanvasPlusPlayground/PeopleManager.swift
+++ b/CanvasPlusPlayground/PeopleManager.swift
@@ -78,8 +78,8 @@ class PeopleManager {
     ) async {
         let courses = await fetchActiveCourses()
 
-        let commonCoursesQueue = DispatchQueue(label: "com.example.commonCoursesQueue")
-        
+        let commonCoursesQueue = DispatchQueue(label: "com.CanvasPlus.commonCoursesQueue")
+
         await withTaskGroup(of: Void.self) { group in
             for course in courses {                
                 // get enrollments in
@@ -114,7 +114,11 @@ class PeopleManager {
                         return
                     }
                     
-                    guard let enrollments: [Enrollment] = try? await CanvasService.shared.syncWithAPI(request) else {
+                    guard let enrollments: [Enrollment] = try? await CanvasService.shared.loadAndSync(request, onCacheReceive: { cached in
+                        guard let cached else { return }
+
+                        processEnrollments(cached)
+                    }) else {
                         // TODO: indicate network error here
                         print("Couldn't fetch enrollment count for course \(course.name ?? "n/a")")
                         return

--- a/CanvasPlusPlayground/Views/PeopleCommonView.swift
+++ b/CanvasPlusPlayground/Views/PeopleCommonView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct PeopleCommonView: View {
     @Environment(PeopleManager.self) var peopleManager
+    @Environment(CourseManager.self) var courseManager
     let user: User
 
     @State private var commonCourses: [Course] = []
@@ -60,11 +61,15 @@ struct PeopleCommonView: View {
     }
 
     private func getCommonCourses() async {
+        guard let id = user.id else { return }
+
         fetchingCommonCourses = true
-        await peopleManager.fetchAllClassesWith(userID: user.id!) {
-            if !commonCourses.contains($0) {
-                commonCourses.append($0)
-            }
+        await peopleManager
+            .fetchAllClassesWith(
+                userID: id,
+                activeCourses: courseManager.courses
+            ) {
+            commonCourses.append($0)
         }
         fetchingCommonCourses = false
     }

--- a/CanvasPlusPlayground/Views/PeopleCommonView.swift
+++ b/CanvasPlusPlayground/Views/PeopleCommonView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct PeopleCommonView: View {
     @Environment(PeopleManager.self) var peopleManager
     let user: User
-    @State var courses: [Course] = []
+    @State var commonCourses: [Course] = []
     @State private var loading: Bool = false
 
     var body: some View {
@@ -19,20 +19,22 @@ struct PeopleCommonView: View {
                 statusLabel
             }
 
-            ForEach(courses, id: \.id) { course in
+            ForEach(commonCourses, id: \.id) { course in
                 Text(course.name ?? "")
             }
         }
         .task {
             loading = true
-            self.courses = await peopleManager.fetchAllClassesWith(userID: user.id!)
+            await peopleManager.fetchAllClassesWith(userID: user.id!) {
+                commonCourses.append($0)
+            }
             loading = false
         }
     }
 
     private var statusLabel: some View {
         HStack {
-            Text("\(courses.count) Common Course\(courses.count == 1 ? "" : "s")")
+            Text("\(commonCourses.count) Common Course\(commonCourses.count == 1 ? "" : "s")")
 
             Spacer()
 


### PR DESCRIPTION
This PR includes the following changes:

- Redesigns the People Backtrack view to use a `GroupedFormStyle` and a few other additions
- Clean up existing code
- Update the people backtrack function to use a closure instead of returning the result, allowing results to update dynamically.
- Use `loadAndSync` to immediately evaluate cached enrollments.

Screen recording:

https://github.com/user-attachments/assets/524ace59-860e-44e1-a6c9-2e79aff17e15