### PR TITLE
Allow users to favorite courses using context menu; `ContentUnavailableView` for People search

### DIFF
--- a/CanvasPlusPlayground/Views/CourseListView.swift
+++ b/CanvasPlusPlayground/Views/CourseListView.swift
@@ -181,7 +181,7 @@ private struct CourseListCell: View {
             } label: {
                 Image(systemName: "star")
                     .symbolVariant(
-                        courseManager.userFavCourses.contains(course)
+                        course.isFavorite ?? false
                         ? .slash
                         : .none
                     )
@@ -193,6 +193,15 @@ private struct CourseListCell: View {
         .contextMenu {
             Button("Change Color", systemImage: "paintbrush.fill") {
                 showColorPicker = true
+            }
+
+            Button(
+                (course.isFavorite ?? false) ? "Unfavorite Course" : "Favorite Course",
+                systemImage: (course.isFavorite ?? false) ? "star.slash.fill" : "star.fill"
+            ) {
+                withAnimation {
+                    course.isFavorite = !(course.isFavorite ?? false)
+                }
             }
         }
         #if os(macOS)

--- a/CanvasPlusPlayground/Views/CourseListView.swift
+++ b/CanvasPlusPlayground/Views/CourseListView.swift
@@ -176,12 +176,12 @@ private struct CourseListCell: View {
         .swipeActions(edge: .leading) {
             Button {
                 withAnimation {
-                    course.isFavorite = !(course.isFavorite ?? false)
+                    course.isFavorite = !wrappedCourseIsFavorite
                 }
             } label: {
                 Image(systemName: "star")
                     .symbolVariant(
-                        course.isFavorite ?? false
+                        wrappedCourseIsFavorite
                         ? .slash
                         : .none
                     )
@@ -196,11 +196,11 @@ private struct CourseListCell: View {
             }
 
             Button(
-                (course.isFavorite ?? false) ? "Unfavorite Course" : "Favorite Course",
-                systemImage: (course.isFavorite ?? false) ? "star.slash.fill" : "star.fill"
+                wrappedCourseIsFavorite ? "Unfavorite Course" : "Favorite Course",
+                systemImage: wrappedCourseIsFavorite ? "star.slash.fill" : "star.fill"
             ) {
                 withAnimation {
-                    course.isFavorite = !(course.isFavorite ?? false)
+                    course.isFavorite = !wrappedCourseIsFavorite
                 }
             }
         }
@@ -219,6 +219,10 @@ private struct CourseListCell: View {
             course.rgbColors = .init(color: resolvedCourseColor)
         }
         #endif
+    }
+
+    private var wrappedCourseIsFavorite: Bool {
+        course.isFavorite ?? false
     }
 }
 

--- a/CanvasPlusPlayground/Views/PeopleView.swift
+++ b/CanvasPlusPlayground/Views/PeopleView.swift
@@ -53,6 +53,11 @@ struct PeopleView: View {
         #else
         .searchable(text: $searchText, prompt: "Search People...")
         #endif
+        .overlay {
+            if !searchText.isEmpty && displayedUsers.isEmpty {
+                ContentUnavailableView("No results for '\(searchText)'", systemImage: "magnifyingglass")
+            }
+        }
     }
 
     private var displayedUsers: [User] {


### PR DESCRIPTION
This PR contains two enhancements:
1. Add ability to favorite/unfavorite a course from the context menu, since the swipe action may be hard to find.
2. Display a content unavailable view when there are no search results in the `PeopleView`.

<img width="1246" alt="Screenshot 2024-11-26 at 9 57 43 AM" src="https://github.com/user-attachments/assets/c189ddb6-57b3-4941-bb9c-7448b71002f8">
<img width="1246" alt="Screenshot 2024-11-26 at 9 58 17 AM" src="https://github.com/user-attachments/assets/59bc384f-b1aa-4254-8afd-beadf19560e5">
