### PR TITLE
Implement @SceneStorage for Navigation Persistence

### DIFF
--- a/CanvasPlusPlayground/Helpers/NavigationModel.swift
+++ b/CanvasPlusPlayground/Helpers/NavigationModel.swift
@@ -7,49 +7,13 @@
 
 import SwiftUI
 
-
-class NavigationModel: ObservableObject {
-    enum CoursePage:String {
+@Observable
+class NavigationModel {
+    enum CoursePage: String {
         case assignments, files, announcements, grades, calendar, people, tabs
     }
 
-    @Published var selectedCourse: Course? {
-        didSet {
-            let dataRep = try! JSONEncoder().encode(selectedCourse)
-            UserDefaults.standard.set(dataRep, forKey: "selectedCourse")
-            selectedCoursePage = nil
-        }
-    }
-    
-    @Published var selectedCoursePage: CoursePage? {
-        didSet {
-            UserDefaults.standard.set(selectedCoursePage?.rawValue, forKey: "selectedPage")
-        }
-    }
-    
-    @Published var showInstallIntelligenceSheet = false
-    
-    
-    init(){
-        let courseData = UserDefaults.standard.data(forKey: "selectedCourse")
-        let pageString = UserDefaults.standard.string(forKey: "selectedPage")
-        print("Nav created")
-        guard let data = courseData else { return }
-        var course:Course? = nil
-        var page:CoursePage? = nil
-        do {
-            course = try JSONDecoder().decode(Course.self, from: data)
-            guard let pageString else { return }
-            print("page content \(pageString)")
-            page = CoursePage(rawValue: pageString)
-            
-        } catch {
-            print("Error fetching selected course from user defaults \(error.localizedDescription)")
-            course = nil
-        }
-        self.selectedCourse = course
-        self.selectedCoursePage = page
-    }
-    
-    
+    var selectedCourse: Course?
+    var selectedCoursePage: CoursePage?
+    var showInstallIntelligenceSheet = false
 }

--- a/CanvasPlusPlayground/Helpers/NavigationModel.swift
+++ b/CanvasPlusPlayground/Helpers/NavigationModel.swift
@@ -13,7 +13,11 @@ class NavigationModel {
         case assignments, files, announcements, grades, calendar, people, tabs
     }
 
-    var selectedCourse: Course?
+    var selectedCourseID: Course.ID? {
+        didSet {
+            selectedCoursePage = nil
+        }
+    }
     var selectedCoursePage: CoursePage?
     var showInstallIntelligenceSheet = false
 }

--- a/CanvasPlusPlayground/Model/Announcement.swift
+++ b/CanvasPlusPlayground/Model/Announcement.swift
@@ -10,6 +10,7 @@ import Foundation
 
 @Model
 final class Announcement: Cacheable {
+    typealias ID = String
     typealias ServerID = Int
     
     @Attribute(.unique) let id: String

--- a/CanvasPlusPlayground/Model/Course.swift
+++ b/CanvasPlusPlayground/Model/Course.swift
@@ -125,6 +125,7 @@ import SwiftData
 
 @Model
 final class Course: Cacheable {
+    typealias ID = String
     typealias ServerID = Int
     
     // MARK: IDs

--- a/CanvasPlusPlayground/Model/Enrollment.swift
+++ b/CanvasPlusPlayground/Model/Enrollment.swift
@@ -10,6 +10,7 @@ import SwiftData
 
 @Model
 final class Enrollment: Cacheable {
+    typealias ID = String
     typealias ServerID = Int
 
     @Attribute(.unique)

--- a/CanvasPlusPlayground/Views/CourseListView.swift
+++ b/CanvasPlusPlayground/Views/CourseListView.swift
@@ -10,9 +10,7 @@ import SwiftUI
 struct CourseListView: View {
     @Environment(CourseManager.self) var courseManager
 
-    
-    @State private var showSheet: Bool = false
-    @StateObject private var navigationModel = NavigationModel()
+    @State private var navigationModel = NavigationModel()
 
     @EnvironmentObject private var intelligenceManager: IntelligenceManager
     @EnvironmentObject private var llmEvaluator: LLMEvaluator
@@ -56,8 +54,7 @@ struct CourseListView: View {
             }
             .interactiveDismissDisabled()
         }
-        .environmentObject(navigationModel)
-        
+        .environment(navigationModel)
         .sheet(isPresented: $navigationModel.showInstallIntelligenceSheet, content: {
             NavigationStack {
                 IntelligenceOnboardingView()

--- a/CanvasPlusPlayground/Views/CourseView.swift
+++ b/CanvasPlusPlayground/Views/CourseView.swift
@@ -8,10 +8,11 @@
 import SwiftUI
 
 struct CourseView: View {
-    @EnvironmentObject private var navigationModel: NavigationModel
+    @Environment(NavigationModel.self) private var navigationModel
     let course: Course
     
     var body: some View {
+        @Bindable var navigationModel = navigationModel
 
         List(selection: $navigationModel.selectedCoursePage) {
             NavigationLink(value: NavigationModel.CoursePage.files) {


### PR DESCRIPTION
This PR:
- reverts the `NavigationModel` back to `@Observable`. The published changes on background thread runtime warning was due to the fact that we would have the properties in NavigationModel be updated on a background thread. By default `@Observable` is a main actor, so we won't have this issue.
- implements a hacky workaround for using `@SceneStorage` for state persistence. We can't use `SceneStorage` in an `@Observable` class, so I've made duplicate `var`s in `CourseListView` and these are updated whenever the navigation model is updated, and vice versa.