### PR TITLE
View Calendar events in app

### DIFF
--- a/CanvasPlusPlayground.xcodeproj/project.pbxproj
+++ b/CanvasPlusPlayground.xcodeproj/project.pbxproj
@@ -61,6 +61,7 @@
 		B7AD54F52CD41D7900FB09BB /* Data.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7AD54EF2CD41D7900FB09BB /* Data.swift */; };
 		B7AD54F62CD41D7900FB09BB /* DeviceStat.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7AD54F02CD41D7900FB09BB /* DeviceStat.swift */; };
 		B7AD550C2CD4257B00FB09BB /* IntelligenceOnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7AD550B2CD4257400FB09BB /* IntelligenceOnboardingView.swift */; };
+		B7D95D772D07C3D3002AD955 /* ICSParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7D95D762D07C3D3002AD955 /* ICSParser.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -118,6 +119,7 @@
 		B7AD54F12CD41D7900FB09BB /* LLMEvaluator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LLMEvaluator.swift; sourceTree = "<group>"; };
 		B7AD54F22CD41D7900FB09BB /* Models.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Models.swift; sourceTree = "<group>"; };
 		B7AD550B2CD4257400FB09BB /* IntelligenceOnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntelligenceOnboardingView.swift; sourceTree = "<group>"; };
+		B7D95D762D07C3D3002AD955 /* ICSParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ICSParser.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -296,6 +298,7 @@
 			isa = PBXGroup;
 			children = (
 				95BA93472C9CE20D00137A91 /* CalendarView.swift */,
+				B7D95D762D07C3D3002AD955 /* ICSParser.swift */,
 			);
 			path = Calendar;
 			sourceTree = "<group>";
@@ -465,6 +468,7 @@
 				3DAE84FE2C9A0CE8008C22E7 /* CoursePDFView.swift in Sources */,
 				9B69FA4F2CC2CCCF006101F3 /* AggregatedAssignmentsViewCell.swift in Sources */,
 				192EC0482C963ACB00AF8528 /* CourseAssignmentManager.swift in Sources */,
+				B7D95D772D07C3D3002AD955 /* ICSParser.swift in Sources */,
 				B76455012C8DF61B002DF00E /* StorageKeys.swift in Sources */,
 				A3FFD03A2CDEC2AC006BAB51 /* LookupCondition.swift in Sources */,
 				A3E7F3932C99338B00DC4300 /* Tab.swift in Sources */,

--- a/CanvasPlusPlayground/Features/Calendar/CalendarView.swift
+++ b/CanvasPlusPlayground/Features/Calendar/CalendarView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct CalendarView: View {
     let icsURL: URL?
 
-    @State private var events = [String: [CanvasCalendarEvent]]()
+    @State private var events = [CanvasCalendarEventGroup]()
 
     init(course: Course) {
         self.icsURL = URL(string: course.calendar?.ics ?? "")
@@ -19,9 +19,9 @@ struct CalendarView: View {
     var body: some View {
         VStack {
             List {
-                ForEach(events.keys.sorted(), id: \.self) { key in
-                    Section(key) {
-                        ForEach(events[key]!) { event in
+                ForEach(events) { eventGroup in
+                    Section(eventGroup.displayDate) {
+                        ForEach(eventGroup.events) { event in
                             EventRow(event: event)
                         }
                     }

--- a/CanvasPlusPlayground/Features/Calendar/CalendarView.swift
+++ b/CanvasPlusPlayground/Features/Calendar/CalendarView.swift
@@ -8,15 +8,66 @@
 import SwiftUI
 
 struct CalendarView: View {
-    let course: Course
+    let icsURL: URL?
+
+    @State private var events = [String: [CanvasCalendarEvent]]()
+
+    init(course: Course) {
+        self.icsURL = URL(string: course.calendar?.ics ?? "")
+    }
+
     var body: some View {
-        Group {
-            if let icsURL = course.calendar?.ics, let url = URL(string: icsURL) {
-                Link("Open in Calendar", destination: url)
-            } else {
-                Text("No calendar available")
+        VStack {
+            List {
+                ForEach(events.keys.sorted(), id: \.self) { key in
+                    Section(key) {
+                        ForEach(events[key]!) { event in
+                            EventRow(event: event)
+                        }
+                    }
+                }
+            }
+            .listStyle(.inset)
+        }
+        .task {
+            events = await ICSParser.parseEvents(from: icsURL)
+        }
+        .overlay {
+            if events.isEmpty {
+                ContentUnavailableView("No events found", systemImage: "calendar.badge.exclamationmark")
+            }
+        }
+        .toolbar {
+            if let icsURL {
+                ToolbarItem(placement: .primaryAction) {
+                    Link(destination: icsURL) {
+                        Label("Open in Calendar", systemImage: "calendar")
+                    }
+                }
             }
         }
         .navigationTitle("Calendar")
+    }
+}
+
+private struct EventRow: View {
+    let event: CanvasCalendarEvent
+
+    var body: some View {
+        HStack {
+            Text(event.summary)
+            Spacer()
+
+            dateDetailText
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var dateDetailText: Text {
+        if event.startDate == event.endDate {
+            Text(event.startDate, style: .time)
+        } else {
+            Text(event.startDate, style: .time) + Text(" - ") + Text(event.endDate, style: .time)
+        }
     }
 }

--- a/CanvasPlusPlayground/Features/Calendar/ICSParser.swift
+++ b/CanvasPlusPlayground/Features/Calendar/ICSParser.swift
@@ -1,0 +1,89 @@
+//
+//  Event.swift
+//  CanvasPlusPlayground
+//
+//  Created by Rahul on 12/9/24.
+//
+
+
+import Foundation
+
+struct CanvasCalendarEvent: Identifiable {
+    let id: String
+    let summary: String
+    let startDate: Date
+    let endDate: Date
+    let location: String
+}
+
+struct ICSParser {
+    private static var dateFormatter: DateFormatter {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyyMMdd'T'HHmmss'Z'"
+        dateFormatter.timeZone = TimeZone(abbreviation: "UTC")
+
+        return dateFormatter
+    }
+
+    private static var groupingDateFormatter: DateFormatter {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateStyle = .medium
+        dateFormatter.timeZone = TimeZone(abbreviation: "UTC")
+        return dateFormatter
+    }
+
+    static func parseEvents(from icsURL: URL?) async -> [String: [CanvasCalendarEvent]] {
+        guard let icsURL else { return [:] }
+
+        let content = await fetchICSContentsFromURL(icsURL)
+
+        var events = [String: [CanvasCalendarEvent]]()
+        let lines = content.components(separatedBy: .newlines)
+        var currentEvent: [String: String] = [:]
+
+        for line in lines {
+            if line.hasPrefix("BEGIN:VEVENT") {
+                currentEvent = [:]
+            } else if line.hasPrefix("END:VEVENT") {
+                if let id = currentEvent["UID"],
+                   let summary = currentEvent["SUMMARY"],
+                   let startDateString = currentEvent["DTSTART"],
+                   let endDateString = currentEvent["DTEND"],
+                   let startDate = dateFormatter.date(from: startDateString),
+                   let endDate = dateFormatter.date(from: endDateString) {
+
+                    let location = currentEvent["LOCATION"] ?? "-"
+
+                    let event = CanvasCalendarEvent(
+                        id: id,
+                        summary: summary,
+                        startDate: startDate,
+                        endDate: endDate,
+                        location: location
+                    )
+
+                    let groupingDate = groupingDateFormatter.string(from: startDate)
+                    events[groupingDate, default: []].append(event)
+                }
+            } else {
+                let components = line.components(separatedBy: ":")
+                if components.count > 1 {
+                    let key = components[0]
+                    let value = components[1...].joined(separator: ":")
+                    currentEvent[key] = value
+                }
+            }
+        }
+
+        return events
+    }
+
+    static private func fetchICSContentsFromURL(_ url: URL) async -> String {
+        guard let data = try? await URLSession.shared.data(from: url).0 else {
+            return ""
+        }
+
+        return String(decoding: data, as: UTF8.self)
+    }
+}
+


### PR DESCRIPTION
Closes #23.

Parse `.ics` files in app and view events without exporting/downloading the `ics` file.

<img src="https://github.com/user-attachments/assets/a9059d3e-3412-41ab-8a36-a37cfb425f34" width="400pt">
<img width="1288" alt="Screenshot 2024-12-09 at 9 20 21 PM" src="https://github.com/user-attachments/assets/8cc63b24-fbee-48eb-b4ce-8c3305c056ce">
