### PR TITLE
Implement announcement previews

### DIFF
--- a/CanvasPlusPlayground/Features/Announcements/AsyncAttributedText.swift
+++ b/CanvasPlusPlayground/Features/Announcements/AsyncAttributedText.swift
@@ -9,12 +9,17 @@ import SwiftUI
 
 struct AsyncAttributedText: View {
     let htmlText: String
+    var textOnly: Bool = false
     @State var announcementText: NSAttributedString? = nil
 
     var body: some View {
         Group {
             if let announcementText {
-                Text(AttributedString(announcementText))
+                if textOnly {
+                    Text(announcementText.string.trimmingCharacters(in: .newlines))
+                } else {
+                    Text(AttributedString(announcementText))
+                }
             } else {
                 ProgressView()
             }

--- a/CanvasPlusPlayground/Features/Announcements/AsyncAttributedText.swift
+++ b/CanvasPlusPlayground/Features/Announcements/AsyncAttributedText.swift
@@ -8,24 +8,30 @@
 import SwiftUI
 
 struct AsyncAttributedText: View {
-    let htmlText: String
+    let announcement: Announcement
+    /// Shows only the text, without HTML formatting
     var textOnly: Bool = false
-    @State var announcementText: NSAttributedString? = nil
+
+    @State var announcementAttributedText: NSAttributedString? = nil
 
     var body: some View {
         Group {
-            if let announcementText {
-                if textOnly {
-                    Text(announcementText.string.trimmingCharacters(in: .newlines))
-                } else {
-                    Text(AttributedString(announcementText))
-                }
+            if textOnly, let announcementText = announcement.announcementText {
+                Text(announcementText)
+            } else if let announcementAttributedText {
+                Text(AttributedString(announcementAttributedText))
             } else {
-                ProgressView()
+                ProgressView().controlSize(.small)
             }
         }
         .task {
-            announcementText = await NSAttributedString.html(withBody: htmlText)
+            if !textOnly || announcement.announcementText == nil {
+                announcementAttributedText = await NSAttributedString
+                    .html(withBody: announcement.message ?? "")
+
+                announcement.announcementText = announcementAttributedText?.string
+                    .trimmingCharacters(in: .newlines)
+            }
         }
     }
 

--- a/CanvasPlusPlayground/Features/Announcements/CourseAnnouncementDetailView.swift
+++ b/CanvasPlusPlayground/Features/Announcements/CourseAnnouncementDetailView.swift
@@ -66,7 +66,7 @@ struct CourseAnnouncementDetailView: View {
             }
 
             Section("Announcement Message") {
-                AsyncAttributedText(htmlText: announcement.message ?? "NULL_MESSAGE")
+                AsyncAttributedText(announcement: announcement)
             }
         }
         .formStyle(.grouped)

--- a/CanvasPlusPlayground/Features/Announcements/CourseAnnouncementDetailView.swift
+++ b/CanvasPlusPlayground/Features/Announcements/CourseAnnouncementDetailView.swift
@@ -70,6 +70,9 @@ struct CourseAnnouncementDetailView: View {
             }
         }
         .formStyle(.grouped)
+        .onAppear {
+            announcement.isRead = true
+        }
     }
 
     private var summarySection: some View {

--- a/CanvasPlusPlayground/Features/Announcements/CourseAnnouncementsView.swift
+++ b/CanvasPlusPlayground/Features/Announcements/CourseAnnouncementsView.swift
@@ -21,20 +21,10 @@ struct CourseAnnouncementsView: View {
             List(announcementManager.announcements, id:\.id) { announcement in
                 NavigationLink {
                     CourseAnnouncementDetailView(announcement: announcement)
-                        .onAppear {
-                            announcement.isRead = true
-                        }
                 } label: {
-                    HStack {
-                        Text(announcement.title ?? "")
-                        Spacer()
-                        if !(announcement.isRead ?? false) {
-                            Circle()
-                                .fill(.tint)
-                                .frame(width: 10, height: 10)
-                        }
-                    }
+                    AnnouncementRow(announcement: announcement)
                 }
+                .tint(course.rgbColors?.color)
             }
             .overlay {
                 if (announcementManager.announcements.count == 0) {
@@ -52,3 +42,56 @@ struct CourseAnnouncementsView: View {
     }
 }
 
+private struct AnnouncementRow: View {
+    let announcement: Announcement
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            header
+            detail
+        }
+    }
+
+    private var header: some View {
+        HStack {
+            if !(announcement.isRead ?? false) {
+                Circle()
+                    .fill(.tint)
+                    .frame(width: unreadIndicatorWidth, height: unreadIndicatorWidth)
+            } else {
+                Spacer().frame(width: unreadIndicatorWidth)
+            }
+
+            Text(announcement.title ?? "")
+
+            Spacer()
+
+            if let createdAt = announcement.createdAt {
+                Text(createdAt.formatted(.relative(presentation: .named)))
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private var detail: some View {
+        HStack {
+            Spacer().frame(width: unreadIndicatorWidth)
+
+            Group {
+                if let summary = announcement.summary {
+                    Text(Image(systemName: "wand.and.sparkles")) + Text(summary)
+                } else {
+                    AsyncAttributedText(
+                        htmlText: announcement.message ?? "",
+                        textOnly: true
+                    )
+                }
+            }
+            .lineLimit(2)
+            .foregroundStyle(.secondary)
+            .controlSize(.small)
+        }
+    }
+
+    private let unreadIndicatorWidth: CGFloat = 10
+}

--- a/CanvasPlusPlayground/Features/Announcements/CourseAnnouncementsView.swift
+++ b/CanvasPlusPlayground/Features/Announcements/CourseAnnouncementsView.swift
@@ -28,7 +28,7 @@ struct CourseAnnouncementsView: View {
             }
             .overlay {
                 if (announcementManager.announcements.count == 0) {
-                    ContentUnavailableView("No announcements available within last 14 days", systemImage: "exclamationmark.bubble.fill")
+                    ContentUnavailableView("No announcements available", systemImage: "exclamationmark.bubble.fill")
                 } else {
                     EmptyView()
                 }
@@ -45,7 +45,7 @@ private struct AnnouncementRow: View {
     let announcement: Announcement
 
     var body: some View {
-        VStack(alignment: .leading) {
+        VStack(alignment: .announcementRowAlignment) {
             header
             detail
         }
@@ -53,15 +53,20 @@ private struct AnnouncementRow: View {
 
     private var header: some View {
         HStack {
-            if !(announcement.isRead ?? false) {
-                Circle()
-                    .fill(.tint)
-                    .frame(width: unreadIndicatorWidth, height: unreadIndicatorWidth)
-            } else {
-                Spacer().frame(width: unreadIndicatorWidth)
+            Group {
+                if !(announcement.isRead ?? false) {
+                    Circle()
+                        .fill(.tint)
+                } else {
+                    Spacer().frame(width: unreadIndicatorWidth)
+                }
             }
+            .frame(width: unreadIndicatorWidth, height: unreadIndicatorWidth)
 
             Text(announcement.title ?? "")
+                .alignmentGuide(.announcementRowAlignment) { context in
+                    context[.leading]
+                }
 
             Spacer()
 
@@ -89,8 +94,23 @@ private struct AnnouncementRow: View {
             .lineLimit(2)
             .foregroundStyle(.secondary)
             .controlSize(.small)
+            .alignmentGuide(.announcementRowAlignment) { context in
+                context[.leading]
+            }
         }
     }
 
     private let unreadIndicatorWidth: CGFloat = 10
+}
+
+extension HorizontalAlignment {
+    private struct AnnouncementRowAlignment: AlignmentID {
+        static func defaultValue(in context: ViewDimensions) -> CGFloat {
+            context[HorizontalAlignment.center]
+        }
+    }
+
+    static let announcementRowAlignment = HorizontalAlignment(
+        AnnouncementRowAlignment.self
+    )
 }

--- a/CanvasPlusPlayground/Features/Announcements/CourseAnnouncementsView.swift
+++ b/CanvasPlusPlayground/Features/Announcements/CourseAnnouncementsView.swift
@@ -45,6 +45,9 @@ private struct AnnouncementRow: View {
     let course: Course
     let announcement: Announcement
 
+    // MARK: Drawing Constants
+    private let unreadIndicatorWidth: CGFloat = 10
+
     var body: some View {
         VStack(alignment: .announcementRowAlignment) {
             header
@@ -105,8 +108,6 @@ private struct AnnouncementRow: View {
             }
         }
     }
-
-    private let unreadIndicatorWidth: CGFloat = 10
 }
 
 extension HorizontalAlignment {

--- a/CanvasPlusPlayground/Features/Announcements/CourseAnnouncementsView.swift
+++ b/CanvasPlusPlayground/Features/Announcements/CourseAnnouncementsView.swift
@@ -32,7 +32,6 @@ struct CourseAnnouncementsView: View {
                 } else {
                     EmptyView()
                 }
-
             }
             .task {
                 await announcementManager.fetchAnnouncements()
@@ -82,7 +81,7 @@ private struct AnnouncementRow: View {
                     Text(Image(systemName: "wand.and.sparkles")) + Text(summary)
                 } else {
                     AsyncAttributedText(
-                        htmlText: announcement.message ?? "",
+                        announcement: announcement,
                         textOnly: true
                     )
                 }

--- a/CanvasPlusPlayground/Features/Announcements/CourseAnnouncementsView.swift
+++ b/CanvasPlusPlayground/Features/Announcements/CourseAnnouncementsView.swift
@@ -22,7 +22,7 @@ struct CourseAnnouncementsView: View {
                 NavigationLink {
                     CourseAnnouncementDetailView(announcement: announcement)
                 } label: {
-                    AnnouncementRow(announcement: announcement)
+                    AnnouncementRow(course: course, announcement: announcement)
                 }
                 .tint(course.rgbColors?.color)
             }
@@ -42,6 +42,7 @@ struct CourseAnnouncementsView: View {
 }
 
 private struct AnnouncementRow: View {
+    let course: Course
     let announcement: Announcement
 
     var body: some View {
@@ -83,7 +84,12 @@ private struct AnnouncementRow: View {
 
             Group {
                 if let summary = announcement.summary {
-                    Text(Image(systemName: "wand.and.sparkles")) + Text(summary)
+                    Text(Image(systemName: "wand.and.sparkles"))
+                        .foregroundStyle(
+                            course.rgbColors?.color ?? .accentColor
+                        )
+                    +
+                    Text(summary)
                 } else {
                     AsyncAttributedText(
                         announcement: announcement,
@@ -110,7 +116,7 @@ extension HorizontalAlignment {
         }
     }
 
-    static let announcementRowAlignment = HorizontalAlignment(
+    fileprivate static let announcementRowAlignment = HorizontalAlignment(
         AnnouncementRowAlignment.self
     )
 }

--- a/CanvasPlusPlayground/Schema/Persistable/Announcement.swift
+++ b/CanvasPlusPlayground/Schema/Persistable/Announcement.swift
@@ -20,6 +20,7 @@ final class Announcement: Cacheable {
 
     // MARK: Custom Properties
     var isRead: Bool?
+    var announcementText: String?
     var summary: String?
 
     weak var course: Course?


### PR DESCRIPTION
- Enhance announcements list with inline previews of the text.
- If an announcement has been summarized, the summary is shown instead with a "wand" next to it.
- Caches preview text for immediate loading.

<img width="1288" alt="Screenshot 2024-12-10 at 6 51 50 PM" src="https://github.com/user-attachments/assets/b002a08e-e658-45ac-9bcc-d34fd214f174">
<img width="400" alt="Simulator Screenshot - iPhone 16 Pro - 2024-12-10 at 18 49 17" src="https://github.com/user-attachments/assets/2f8baec0-c9f8-4fe1-b5dc-48b9ff301312">


