### PR TITLE
Pinned Items Implementation

### DIFF
--- a/CanvasPlusPlayground.xcodeproj/project.pbxproj
+++ b/CanvasPlusPlayground.xcodeproj/project.pbxproj
@@ -115,6 +115,11 @@
 		B7AD54F52CD41D7900FB09BB /* Data.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7AD54EF2CD41D7900FB09BB /* Data.swift */; };
 		B7AD54F62CD41D7900FB09BB /* DeviceStat.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7AD54F02CD41D7900FB09BB /* DeviceStat.swift */; };
 		B7AD550C2CD4257B00FB09BB /* IntelligenceOnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7AD550B2CD4257400FB09BB /* IntelligenceOnboardingView.swift */; };
+		B7C0A3BD2D2F1F2E003E5A36 /* PinnedItemsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7C0A3BC2D2F1F25003E5A36 /* PinnedItemsManager.swift */; };
+		B7C0A3BF2D2F2251003E5A36 /* PinnedItemsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7C0A3BE2D2F224C003E5A36 /* PinnedItemsView.swift */; };
+		B7C0A3C52D2F4C19003E5A36 /* GetAssignmentRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7C0A3C42D2F4C11003E5A36 /* GetAssignmentRequest.swift */; };
+		B7C0A3C72D2F4E82003E5A36 /* GetFileRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7C0A3C62D2F4E82003E5A36 /* GetFileRequest.swift */; };
+		B7C0A3C92D2F87EC003E5A36 /* AsyncView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7C0A3C82D2F87E9003E5A36 /* AsyncView.swift */; };
 		B7D95D772D07C3D3002AD955 /* ICSParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7D95D762D07C3D3002AD955 /* ICSParser.swift */; };
 		B7D95DB72D0A8D78002AD955 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7D95DB62D0A8D75002AD955 /* SettingsView.swift */; };
 		B7E59A102D2002A5001836FE /* Sidebar.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7E59A0F2D2002A3001836FE /* Sidebar.swift */; };
@@ -238,6 +243,11 @@
 		B7AD54F12CD41D7900FB09BB /* LLMEvaluator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LLMEvaluator.swift; sourceTree = "<group>"; };
 		B7AD54F22CD41D7900FB09BB /* Models.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Models.swift; sourceTree = "<group>"; };
 		B7AD550B2CD4257400FB09BB /* IntelligenceOnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntelligenceOnboardingView.swift; sourceTree = "<group>"; };
+		B7C0A3BC2D2F1F25003E5A36 /* PinnedItemsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinnedItemsManager.swift; sourceTree = "<group>"; };
+		B7C0A3BE2D2F224C003E5A36 /* PinnedItemsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinnedItemsView.swift; sourceTree = "<group>"; };
+		B7C0A3C42D2F4C11003E5A36 /* GetAssignmentRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetAssignmentRequest.swift; sourceTree = "<group>"; };
+		B7C0A3C62D2F4E82003E5A36 /* GetFileRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetFileRequest.swift; sourceTree = "<group>"; };
+		B7C0A3C82D2F87E9003E5A36 /* AsyncView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncView.swift; sourceTree = "<group>"; };
 		B7D95D762D07C3D3002AD955 /* ICSParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ICSParser.swift; sourceTree = "<group>"; };
 		B7D95DB62D0A8D75002AD955 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		B7E59A0F2D2002A3001836FE /* Sidebar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar.swift; sourceTree = "<group>"; };
@@ -280,11 +290,13 @@
 				A3049B762D15DC36002F3166 /* GetCourseRequest.swift */,
 				A3049B742D15DC1C002F3166 /* GetCoursesRequest.swift */,
 				A3049B782D15E162002F3166 /* GetCourseRootFolder.swift */,
+				B7C0A3C62D2F4E82003E5A36 /* GetFileRequest.swift */,
 				A3049B7A2D15E2B7002F3166 /* GetFilesInFolderRequest.swift */,
 				A3049B7C2D160299002F3166 /* GetFoldersInFolderRequest.swift */,
 				A3049B7E2D160C03002F3166 /* GetTabsRequest.swift */,
 				A3049B802D160F6B002F3166 /* GetAnnouncementsRequest.swift */,
 				A3049B822D161432002F3166 /* GetAssignmentsRequest.swift */,
+				B7C0A3C42D2F4C11003E5A36 /* GetAssignmentRequest.swift */,
 				A3049B842D161455002F3166 /* GetEnrollmentsRequest.swift */,
 				A3049B862D16146D002F3166 /* GetQuizzesRequest.swift */,
 				A3D1614E2D1784E3004055FB /* GetUserRequest.swift */,
@@ -299,6 +311,7 @@
 			isa = PBXGroup;
 			children = (
 				A373DC2E2D28174700215019 /* Modules */,
+				B7C5532A2D2D5AEB009CF4F0 /* Pinned Items */,
 				B7E59A0E2D200281001836FE /* Navigation */,
 				B7F950352D12785D004BB470 /* Profile */,
 				A3049B642D0F3E26002F3166 /* Quiz */,
@@ -382,6 +395,7 @@
 		A324BA562D0796C3005F53FA /* Components */ = {
 			isa = PBXGroup;
 			children = (
+				B7C0A3C82D2F87E9003E5A36 /* AsyncView.swift */,
 				B7F950332D11A00F004BB470 /* StatusToolbarItem.swift */,
 				B7926D172CE962C200BFFBE1 /* ColorPickerWithoutLabel.swift */,
 				3DAE84FF2C9A0E4F008C22E7 /* PDFViewHelper.swift */,
@@ -616,6 +630,15 @@
 			path = Intelligence;
 			sourceTree = "<group>";
 		};
+		B7C5532A2D2D5AEB009CF4F0 /* Pinned Items */ = {
+			isa = PBXGroup;
+			children = (
+				B7C0A3BE2D2F224C003E5A36 /* PinnedItemsView.swift */,
+				B7C0A3BC2D2F1F25003E5A36 /* PinnedItemsManager.swift */,
+			);
+			path = "Pinned Items";
+			sourceTree = "<group>";
+		};
 		B7D95DB52D0A8D6A002AD955 /* Settings */ = {
 			isa = PBXGroup;
 			children = (
@@ -744,6 +767,7 @@
 				B7926D162CE95CED00BFFBE1 /* RGBColors.swift in Sources */,
 				3DAE84FE2C9A0CE8008C22E7 /* CoursePDFView.swift in Sources */,
 				A3049B632D0E6154002F3166 /* ScoringPolicy.swift in Sources */,
+				B7C0A3C92D2F87EC003E5A36 /* AsyncView.swift in Sources */,
 				9B69FA4F2CC2CCCF006101F3 /* AggregatedAssignmentsViewCell.swift in Sources */,
 				B7F950372D127869004BB470 /* ProfileManager.swift in Sources */,
 				A324BA662D07AFD5005F53FA /* FileType.swift in Sources */,
@@ -764,6 +788,7 @@
 				B76455032C8DF61B002DF00E /* HomeView.swift in Sources */,
 				A3269E8E2CD5533F006F7D14 /* CanvasRepository.swift in Sources */,
 				A3049B5B2D0E5C18002F3166 /* QuizPermissions.swift in Sources */,
+				B7C0A3C52D2F4C19003E5A36 /* GetAssignmentRequest.swift in Sources */,
 				A3FFD03E2CE0065A006BAB51 /* NetworkError.swift in Sources */,
 				B7E59A142D2004A4001836FE /* CourseListCell.swift in Sources */,
 				B53D95A22CA0A22A00647EE9 /* PeopleView.swift in Sources */,
@@ -811,6 +836,7 @@
 				B76455062C8DF61B002DF00E /* CanvasPlusPlaygroundApp.swift in Sources */,
 				B7F950342D11A00F004BB470 /* StatusToolbarItem.swift in Sources */,
 				9B69FA4B2CC2CC7F006101F3 /* AggregatedAssignmentsView.swift in Sources */,
+				B7C0A3BF2D2F2251003E5A36 /* PinnedItemsView.swift in Sources */,
 				A3CF88E32D1921CB000ACDF3 /* FolderAPI.swift in Sources */,
 				A373DC2D2D28172E00215019 /* GetModulesRequest.swift in Sources */,
 				B76455072C8DF61B002DF00E /* CourseFileViewModel.swift in Sources */,
@@ -820,10 +846,12 @@
 				A3049B532D0E5241002F3166 /* Quiz.swift in Sources */,
 				A3049B872D16146D002F3166 /* GetQuizzesRequest.swift in Sources */,
 				A3269E902CD57F75006F7D14 /* Cacheable.swift in Sources */,
+				B7C0A3BD2D2F1F2E003E5A36 /* PinnedItemsManager.swift in Sources */,
 				A3049B5D2D0E5D5A002F3166 /* APIAssignmentDate.swift in Sources */,
 				3DAE85002C9A0E4F008C22E7 /* PDFViewHelper.swift in Sources */,
 				B533C0BE2CADDDE700A74AF6 /* PeopleCommonView.swift in Sources */,
 				B7926D182CE962C200BFFBE1 /* ColorPickerWithoutLabel.swift in Sources */,
+				B7C0A3C72D2F4E82003E5A36 /* GetFileRequest.swift in Sources */,
 				A31A81E72D0CCB69003C37EB /* GradesViewModel.swift in Sources */,
 				A373DC142D19FA2A00215019 /* APICourseSection.swift in Sources */,
 				A3E7F38B2C9555B200DC4300 /* CanvasService.swift in Sources */,

--- a/CanvasPlusPlayground.xcodeproj/project.pbxproj
+++ b/CanvasPlusPlayground.xcodeproj/project.pbxproj
@@ -122,6 +122,7 @@
 		B7C0A3C92D2F87EC003E5A36 /* AsyncView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7C0A3C82D2F87E9003E5A36 /* AsyncView.swift */; };
 		B7C0A3CB2D2F919F003E5A36 /* PinButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7C0A3CA2D2F919F003E5A36 /* PinButton.swift */; };
 		B7C0A3CD2D3023CA003E5A36 /* PinnedItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7C0A3CC2D3023CA003E5A36 /* PinnedItem.swift */; };
+		B7C0A3CF2D31F339003E5A36 /* PinnedItemCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7C0A3CE2D31F339003E5A36 /* PinnedItemCard.swift */; };
 		B7D95D772D07C3D3002AD955 /* ICSParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7D95D762D07C3D3002AD955 /* ICSParser.swift */; };
 		B7D95DB72D0A8D78002AD955 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7D95DB62D0A8D75002AD955 /* SettingsView.swift */; };
 		B7E59A102D2002A5001836FE /* Sidebar.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7E59A0F2D2002A3001836FE /* Sidebar.swift */; };
@@ -252,6 +253,7 @@
 		B7C0A3C82D2F87E9003E5A36 /* AsyncView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncView.swift; sourceTree = "<group>"; };
 		B7C0A3CA2D2F919F003E5A36 /* PinButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinButton.swift; sourceTree = "<group>"; };
 		B7C0A3CC2D3023CA003E5A36 /* PinnedItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinnedItem.swift; sourceTree = "<group>"; };
+		B7C0A3CE2D31F339003E5A36 /* PinnedItemCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinnedItemCard.swift; sourceTree = "<group>"; };
 		B7D95D762D07C3D3002AD955 /* ICSParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ICSParser.swift; sourceTree = "<group>"; };
 		B7D95DB62D0A8D75002AD955 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		B7E59A0F2D2002A3001836FE /* Sidebar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar.swift; sourceTree = "<group>"; };
@@ -637,9 +639,10 @@
 		B7C5532A2D2D5AEB009CF4F0 /* Pinned Items */ = {
 			isa = PBXGroup;
 			children = (
-				B7C0A3CC2D3023CA003E5A36 /* PinnedItem.swift */,
 				B7C0A3CA2D2F919F003E5A36 /* PinButton.swift */,
 				B7C0A3BE2D2F224C003E5A36 /* PinnedItemsView.swift */,
+				B7C0A3CE2D31F339003E5A36 /* PinnedItemCard.swift */,
+				B7C0A3CC2D3023CA003E5A36 /* PinnedItem.swift */,
 				B7C0A3BC2D2F1F25003E5A36 /* PinnedItemsManager.swift */,
 			);
 			path = "Pinned Items";
@@ -780,6 +783,7 @@
 				192EC0482C963ACB00AF8528 /* CourseAssignmentManager.swift in Sources */,
 				A373DC232D1D454000215019 /* APIGradingSchemeEntry.swift in Sources */,
 				A373DC252D1D4BEC00215019 /* APIQuizSubmission.swift in Sources */,
+				B7C0A3CF2D31F339003E5A36 /* PinnedItemCard.swift in Sources */,
 				B7D95D772D07C3D3002AD955 /* ICSParser.swift in Sources */,
 				A3CF88D32D18E6BB000ACDF3 /* ParentKeyPath.swift in Sources */,
 				B7F9503B2D127AD0004BB470 /* ProfileAPI.swift in Sources */,

--- a/CanvasPlusPlayground.xcodeproj/project.pbxproj
+++ b/CanvasPlusPlayground.xcodeproj/project.pbxproj
@@ -121,6 +121,7 @@
 		B7C0A3C72D2F4E82003E5A36 /* GetFileRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7C0A3C62D2F4E82003E5A36 /* GetFileRequest.swift */; };
 		B7C0A3C92D2F87EC003E5A36 /* AsyncView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7C0A3C82D2F87E9003E5A36 /* AsyncView.swift */; };
 		B7C0A3CB2D2F919F003E5A36 /* PinButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7C0A3CA2D2F919F003E5A36 /* PinButton.swift */; };
+		B7C0A3CD2D3023CA003E5A36 /* PinnedItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7C0A3CC2D3023CA003E5A36 /* PinnedItem.swift */; };
 		B7D95D772D07C3D3002AD955 /* ICSParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7D95D762D07C3D3002AD955 /* ICSParser.swift */; };
 		B7D95DB72D0A8D78002AD955 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7D95DB62D0A8D75002AD955 /* SettingsView.swift */; };
 		B7E59A102D2002A5001836FE /* Sidebar.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7E59A0F2D2002A3001836FE /* Sidebar.swift */; };
@@ -250,6 +251,7 @@
 		B7C0A3C62D2F4E82003E5A36 /* GetFileRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetFileRequest.swift; sourceTree = "<group>"; };
 		B7C0A3C82D2F87E9003E5A36 /* AsyncView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncView.swift; sourceTree = "<group>"; };
 		B7C0A3CA2D2F919F003E5A36 /* PinButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinButton.swift; sourceTree = "<group>"; };
+		B7C0A3CC2D3023CA003E5A36 /* PinnedItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinnedItem.swift; sourceTree = "<group>"; };
 		B7D95D762D07C3D3002AD955 /* ICSParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ICSParser.swift; sourceTree = "<group>"; };
 		B7D95DB62D0A8D75002AD955 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		B7E59A0F2D2002A3001836FE /* Sidebar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar.swift; sourceTree = "<group>"; };
@@ -635,6 +637,7 @@
 		B7C5532A2D2D5AEB009CF4F0 /* Pinned Items */ = {
 			isa = PBXGroup;
 			children = (
+				B7C0A3CC2D3023CA003E5A36 /* PinnedItem.swift */,
 				B7C0A3CA2D2F919F003E5A36 /* PinButton.swift */,
 				B7C0A3BE2D2F224C003E5A36 /* PinnedItemsView.swift */,
 				B7C0A3BC2D2F1F25003E5A36 /* PinnedItemsManager.swift */,
@@ -843,6 +846,7 @@
 				B7C0A3BF2D2F2251003E5A36 /* PinnedItemsView.swift in Sources */,
 				A3CF88E32D1921CB000ACDF3 /* FolderAPI.swift in Sources */,
 				A373DC2D2D28172E00215019 /* GetModulesRequest.swift in Sources */,
+				B7C0A3CD2D3023CA003E5A36 /* PinnedItem.swift in Sources */,
 				B76455072C8DF61B002DF00E /* CourseFileViewModel.swift in Sources */,
 				A351913F2D283556001E415F /* ModulesListView.swift in Sources */,
 				A3CF88DF2D1921B5000ACDF3 /* FileAPI.swift in Sources */,

--- a/CanvasPlusPlayground.xcodeproj/project.pbxproj
+++ b/CanvasPlusPlayground.xcodeproj/project.pbxproj
@@ -120,6 +120,7 @@
 		B7C0A3C52D2F4C19003E5A36 /* GetAssignmentRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7C0A3C42D2F4C11003E5A36 /* GetAssignmentRequest.swift */; };
 		B7C0A3C72D2F4E82003E5A36 /* GetFileRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7C0A3C62D2F4E82003E5A36 /* GetFileRequest.swift */; };
 		B7C0A3C92D2F87EC003E5A36 /* AsyncView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7C0A3C82D2F87E9003E5A36 /* AsyncView.swift */; };
+		B7C0A3CB2D2F919F003E5A36 /* PinButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7C0A3CA2D2F919F003E5A36 /* PinButton.swift */; };
 		B7D95D772D07C3D3002AD955 /* ICSParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7D95D762D07C3D3002AD955 /* ICSParser.swift */; };
 		B7D95DB72D0A8D78002AD955 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7D95DB62D0A8D75002AD955 /* SettingsView.swift */; };
 		B7E59A102D2002A5001836FE /* Sidebar.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7E59A0F2D2002A3001836FE /* Sidebar.swift */; };
@@ -248,6 +249,7 @@
 		B7C0A3C42D2F4C11003E5A36 /* GetAssignmentRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetAssignmentRequest.swift; sourceTree = "<group>"; };
 		B7C0A3C62D2F4E82003E5A36 /* GetFileRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetFileRequest.swift; sourceTree = "<group>"; };
 		B7C0A3C82D2F87E9003E5A36 /* AsyncView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncView.swift; sourceTree = "<group>"; };
+		B7C0A3CA2D2F919F003E5A36 /* PinButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinButton.swift; sourceTree = "<group>"; };
 		B7D95D762D07C3D3002AD955 /* ICSParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ICSParser.swift; sourceTree = "<group>"; };
 		B7D95DB62D0A8D75002AD955 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		B7E59A0F2D2002A3001836FE /* Sidebar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar.swift; sourceTree = "<group>"; };
@@ -633,6 +635,7 @@
 		B7C5532A2D2D5AEB009CF4F0 /* Pinned Items */ = {
 			isa = PBXGroup;
 			children = (
+				B7C0A3CA2D2F919F003E5A36 /* PinButton.swift */,
 				B7C0A3BE2D2F224C003E5A36 /* PinnedItemsView.swift */,
 				B7C0A3BC2D2F1F25003E5A36 /* PinnedItemsManager.swift */,
 			);
@@ -827,6 +830,7 @@
 				192EC04C2C963EE600AF8528 /* CourseAssignmentView.swift in Sources */,
 				A3FFD03C2CDED67C006BAB51 /* String+Numbers.swift in Sources */,
 				B53D95A02CA0953900647EE9 /* PeopleManager.swift in Sources */,
+				B7C0A3CB2D2F919F003E5A36 /* PinButton.swift in Sources */,
 				B7F950392D1279A1004BB470 /* UserAPI.swift in Sources */,
 				A3049B662D0F3E32002F3166 /* CourseQuizzesView.swift in Sources */,
 				A3E7F3892C954E0500DC4300 /* CanvasRequest.swift in Sources */,

--- a/CanvasPlusPlayground/CanvasPlusPlaygroundApp.swift
+++ b/CanvasPlusPlayground/CanvasPlusPlaygroundApp.swift
@@ -9,9 +9,15 @@ import SwiftUI
 
 @main
 struct CanvasPlusPlaygroundApp: App {
+    // Navigation
+    @State private var navigationModel = NavigationModel()
+
+    // App
     @State private var profileManager = ProfileManager()
     @State private var courseManager = CourseManager()
-    @State private var navigationModel = NavigationModel()
+    @State private var pinnedItemsManager = PinnedItemsManager()
+
+    // Intelligence
     @StateObject private var intelligenceManager = IntelligenceManager()
     @StateObject private var llmEvaluator = LLMEvaluator()
 
@@ -20,6 +26,7 @@ struct CanvasPlusPlaygroundApp: App {
             HomeView()
                 .environment(profileManager)
                 .environment(courseManager)
+                .environment(pinnedItemsManager)
                 .environment(navigationModel)
                 .environmentObject(intelligenceManager)
                 .environmentObject(llmEvaluator)
@@ -34,6 +41,7 @@ struct CanvasPlusPlaygroundApp: App {
             SettingsView()
                 .environment(profileManager)
                 .environment(courseManager)
+                .environment(pinnedItemsManager)
                 .environment(navigationModel)
                 .environmentObject(intelligenceManager)
                 .environmentObject(llmEvaluator)

--- a/CanvasPlusPlayground/Common/Components/AsyncView.swift
+++ b/CanvasPlusPlayground/Common/Components/AsyncView.swift
@@ -23,8 +23,8 @@ struct AsyncView<T, Content: View, Placeholder: View>: View {
     }
 
     let asyncFunction: () async -> T?
-    let content: (T) -> Content
-    let placeholder: () -> Placeholder
+    @ViewBuilder let content: (T) -> Content
+    @ViewBuilder let placeholder: () -> Placeholder
 
     @State var viewState: LoadingState = .loading
 

--- a/CanvasPlusPlayground/Common/Components/AsyncView.swift
+++ b/CanvasPlusPlayground/Common/Components/AsyncView.swift
@@ -1,0 +1,49 @@
+//
+//  AsyncView.swift
+//  CanvasPlusPlayground
+//
+//  Created by Rahul on 1/8/25.
+//
+
+import SwiftUI
+
+struct AsyncView<T, Content: View, Placeholder: View>: View {
+    enum LoadingState: Equatable {
+        case loading
+        case loaded(T)
+        case failed
+
+        static func == (lhs: AsyncView<T, Content, Placeholder>.LoadingState, rhs: AsyncView<T, Content, Placeholder>.LoadingState) -> Bool {
+            switch (lhs, rhs) {
+            case (.loading, .loading), (.loaded, .loaded), (.failed, .failed):
+                return true
+            default: return false
+            }
+        }
+    }
+
+    let asyncFunction: () async -> T?
+    let content: (T) -> Content
+    let placeholder: () -> Placeholder
+
+    @State var viewState: LoadingState = .loading
+
+    var body: some View {
+        Group {
+            if viewState == .loading {
+                placeholder()
+            } else if case .loaded(let data) = viewState {
+                content(data)
+            } else {
+                EmptyView()
+            }
+        }
+        .task {
+            if let result = await asyncFunction() {
+                viewState = .loaded(result)
+            } else {
+                viewState = .failed
+            }
+        }
+    }
+}

--- a/CanvasPlusPlayground/Common/Network/API Requests/GetAssignmentRequest.swift
+++ b/CanvasPlusPlayground/Common/Network/API Requests/GetAssignmentRequest.swift
@@ -1,0 +1,82 @@
+//
+//  GetAssignmentRequest.swift
+//  CanvasPlusPlayground
+//
+//  Created by Rahul on 1/8/25.
+//
+
+import Foundation
+
+struct GetAssignmentRequest: APIRequest {
+    typealias Subject = AssignmentAPI
+
+    let assignmentId: String
+    let courseId: String
+
+    var path: String { "courses/\(courseId)/assignments/\(assignmentId)" }
+    var queryParameters: [QueryParameter] {
+        [
+            ("override_assignment_dates", overrideAssignmentDates),
+            ("needs_grading_count_by_section", needsGradingCountBySection),
+            ("all_dates", allDates)
+        ]
+        + include.map { ("include[]", $0) }
+    }
+
+    // MARK: Query Params
+    let include: [String]
+    let overrideAssignmentDates: Bool?
+    let needsGradingCountBySection: Bool?
+    let allDates: Bool?
+
+    init(
+        assignmentId: String,
+        courseId: String,
+        include: [String] = [],
+        overrideAssignmentDates: Bool? = nil,
+        needsGradingCountBySection: Bool? = nil,
+        allDates: Bool? = nil
+    ) {
+        self.assignmentId = assignmentId
+        self.courseId = courseId
+        self.include = include
+        self.overrideAssignmentDates = overrideAssignmentDates
+        self.needsGradingCountBySection = needsGradingCountBySection
+        self.allDates = allDates
+    }
+
+    /* Assignment isn't cacheable, reimplement when it is
+    // MARK: Request Id
+    var requestId: Int? { courseId.asInt }
+    var requestIdKey: ParentKeyPath<Assignment, Int?> { .createReadable(\.courseId) }
+    var idPredicate: Predicate<Assignment> {
+        #Predicate<Assignment> { assignment in
+            assignment.courseId == requestId
+        }
+    }
+    var customPredicate: Predicate<Assignment> {
+        let searchTerm = searchTerm ?? ""
+        let searchPred = #Predicate<Assignment> { assignment in
+            assignment.name.contains(searchTerm)
+        }
+
+        let ids = assignmentIds.compactMap(\.?.asInt)
+        let assignmentIdsPred = assignmentIds.isEmpty ? .true :  #Predicate<Assignment> { assignment in
+            ids.contains(assignment.id)
+        }
+
+        let postToSisPred: Predicate<Assignment>
+        if let postToSis {
+            postToSisPred = #Predicate<Assignment> { assignment in
+                assignment.postToSis == postToSis
+            }
+        } else { postToSisPred = .true }
+
+        return #Predicate<Assignment> { assignment in
+            searchPred.evaluate(assignment) && assignmentIdsPred.evaluate(assignment) && postToSisPred.evaluate(assignment)
+        }
+
+        // TODO: add remaining filters (bucket, assignmentIds)
+    }*/
+
+}

--- a/CanvasPlusPlayground/Common/Network/API Requests/GetFileRequest.swift
+++ b/CanvasPlusPlayground/Common/Network/API Requests/GetFileRequest.swift
@@ -1,0 +1,55 @@
+//
+//  GetFileRequest.swift
+//  CanvasPlusPlayground
+//
+//  Created by Rahul on 1/8/25.
+//
+
+import Foundation
+
+struct GetFileRequest: CacheableAPIRequest {
+    typealias Subject = FileAPI
+
+    let fileId: String
+    let include: [String]
+    let replacementChainContextType: String?
+    let replacementChainContextId: Int?
+
+    // MARK: Path
+    var path: String { "files/\(fileId)" }
+
+    // MARK: Query Parameters
+    var queryParameters: [QueryParameter] {
+        [
+            ("include[]", include.joined(separator: ",")),
+            ("replacement_chain_context_type", replacementChainContextType),
+            ("replacement_chain_context_id", replacementChainContextId?.description)
+        ]
+    }
+
+    // MARK: Initializer
+    init(
+        fileId: String,
+        include: [String] = [],
+        replacementChainContextType: String? = nil,
+        replacementChainContextId: Int? = nil
+    ) {
+        self.fileId = fileId
+        self.include = include
+        self.replacementChainContextType = replacementChainContextType
+        self.replacementChainContextId = replacementChainContextId
+    }
+
+    // MARK: Request ID
+    var requestId: String { fileId }
+    var requestIdKey: ParentKeyPath<File, String> { .createWritable(\.id) }
+    var idPredicate: Predicate<File> {
+        #Predicate<File> { file in
+            file.id == fileId
+        }
+    }
+
+    var customPredicate: Predicate<File> {
+        .true
+    }
+}

--- a/CanvasPlusPlayground/Common/Network/API Requests/GetFileRequest.swift
+++ b/CanvasPlusPlayground/Common/Network/API Requests/GetFileRequest.swift
@@ -42,7 +42,7 @@ struct GetFileRequest: CacheableAPIRequest {
 
     // MARK: Request ID
     var requestId: String { fileId }
-    var requestIdKey: ParentKeyPath<File, String> { .createWritable(\.id) }
+    var requestIdKey: ParentKeyPath<File, String> { .createReadable(\.id) }
     var idPredicate: Predicate<File> {
         #Predicate<File> { file in
             file.id == fileId

--- a/CanvasPlusPlayground/Common/Network/CanvasRequest.swift
+++ b/CanvasPlusPlayground/Common/Network/CanvasRequest.swift
@@ -20,6 +20,10 @@ struct CanvasRequest {
         GetCourseRootFolderRequest(courseId: courseId)
     }
 
+    static func getFile(fileId: String) -> GetFileRequest {
+        GetFileRequest(fileId: fileId)
+    }
+
     static func getFilesInFolder(folderId: String) -> GetFilesInFolderRequest {
         GetFilesInFolderRequest(folderId: folderId)
     }
@@ -39,6 +43,10 @@ struct CanvasRequest {
         perPage: Int = 15
     ) -> GetAnnouncementsRequest {
         GetAnnouncementsRequest(courseId: courseId, startDate: startDate, endDate: endDate, perPage: perPage)
+    }
+
+    static func getAssignment(id: String, courseId: String) -> GetAssignmentRequest {
+        GetAssignmentRequest(assignmentId: id, courseId: courseId)
     }
 
     static func getAssignments(courseId: String) -> GetAssignmentsRequest {

--- a/CanvasPlusPlayground/Features/Announcements/CourseAnnouncementsView.swift
+++ b/CanvasPlusPlayground/Features/Announcements/CourseAnnouncementsView.swift
@@ -57,8 +57,6 @@ struct CourseAnnouncementsView: View {
 }
 
 private struct AnnouncementRow: View {
-    @Environment(PinnedItemsManager.self) private var pinnedItemsManager
-
     let course: Course
     let announcement: Announcement
 
@@ -70,20 +68,17 @@ private struct AnnouncementRow: View {
             header
             detail
         }
+        .contextMenu {
+            PinButton(
+                itemID: announcement.id,
+                courseID: course.id,
+                type: .announcement
+            )
+        }
     }
 
     private var header: some View {
         HStack {
-            Button("Pin", systemImage: "pin") {
-                pinnedItemsManager.pinnedItems.append(
-                    PinnedItem.init(
-                        id: announcement.id,
-                        courseID: course.id,
-                        type: .announcement
-                    )
-                )
-            }
-
             Group {
                 if !(announcement.isRead ?? false) {
                     Circle()

--- a/CanvasPlusPlayground/Features/Announcements/CourseAnnouncementsView.swift
+++ b/CanvasPlusPlayground/Features/Announcements/CourseAnnouncementsView.swift
@@ -75,6 +75,13 @@ private struct AnnouncementRow: View {
                 type: .announcement
             )
         }
+        .swipeActions(edge: .leading) {
+            PinButton(
+                itemID: announcement.id,
+                courseID: course.id,
+                type: .announcement
+            )
+        }
     }
 
     private var header: some View {

--- a/CanvasPlusPlayground/Features/Announcements/CourseAnnouncementsView.swift
+++ b/CanvasPlusPlayground/Features/Announcements/CourseAnnouncementsView.swift
@@ -57,6 +57,8 @@ struct CourseAnnouncementsView: View {
 }
 
 private struct AnnouncementRow: View {
+    @Environment(PinnedItemsManager.self) private var pinnedItemsManager
+
     let course: Course
     let announcement: Announcement
 
@@ -72,6 +74,16 @@ private struct AnnouncementRow: View {
 
     private var header: some View {
         HStack {
+            Button("Pin", systemImage: "pin") {
+                pinnedItemsManager.pinnedItems.append(
+                    PinnedItem.init(
+                        id: announcement.id,
+                        courseID: course.id,
+                        type: .announcement
+                    )
+                )
+            }
+
             Group {
                 if !(announcement.isRead ?? false) {
                     Circle()

--- a/CanvasPlusPlayground/Features/Assignments/CourseAssignmentView.swift
+++ b/CanvasPlusPlayground/Features/Assignments/CourseAssignmentView.swift
@@ -22,30 +22,21 @@ struct CourseAssignmentsView: View {
 
     var body: some View {
         List(assignmentManager.assignments, id: \.id) { assignment in
-            let submission = assignment.submission?.createModel()
-
-            HStack {
-                VStack(alignment: .leading) {
-                    Text(assignment.name)
-                        .font(.headline)
-                    Group {
-                        if let submission {
-                            Text(
-                                submission.workflowState?.rawValue.capitalized ?? "Unknown Status"
-                            )
-                        }
-                    }
-                    .font(.subheadline)
+            AssignmentRow(assignment: assignment, showGrades: showGrades)
+                .contextMenu {
+                    PinButton(
+                        itemID: assignment.id.asString,
+                        courseID: course.id,
+                        type: .assignment
+                    )
                 }
-
-                if showGrades, let submission {
-                    Spacer()
-
-                    Text(submission.score?.truncatingTrailingZeros ?? "--") +
-                    Text("/") +
-                    Text(assignment.points_possible?.truncatingTrailingZeros ?? "--")
+                .swipeActions(edge: .leading) {
+                    PinButton(
+                        itemID: assignment.id.asString,
+                        courseID: course.id,
+                        type: .assignment
+                    )
                 }
-            }
         }
         .task {
             await loadAssignments()
@@ -58,5 +49,37 @@ struct CourseAssignmentsView: View {
         isLoadingAssignments = true
         await assignmentManager.fetchAssignments()
         isLoadingAssignments = false
+    }
+}
+
+struct AssignmentRow: View {
+    let assignment: AssignmentAPI
+    let showGrades: Bool
+
+    var body: some View {
+        let submission = assignment.submission?.createModel()
+
+        HStack {
+            VStack(alignment: .leading) {
+                Text(assignment.name)
+                    .font(.headline)
+                Group {
+                    if let submission {
+                        Text(
+                            submission.workflowState?.rawValue.capitalized ?? "Unknown Status"
+                        )
+                    }
+                }
+                .font(.subheadline)
+            }
+
+            if showGrades, let submission {
+                Spacer()
+
+                Text(submission.score?.truncatingTrailingZeros ?? "--") +
+                Text("/") +
+                Text(assignment.points_possible?.truncatingTrailingZeros ?? "--")
+            }
+        }
     }
 }

--- a/CanvasPlusPlayground/Features/Files/FoldersPageView.swift
+++ b/CanvasPlusPlayground/Features/Files/FoldersPageView.swift
@@ -54,6 +54,20 @@ struct FoldersPageView: View {
             NavigationLink(destination: destination(for: file)) {
                 Label(file.displayName, systemImage: "document")
             }
+            .contextMenu {
+                PinButton(
+                    itemID: file.id,
+                    courseID: course.id,
+                    type: .file
+                )
+            }
+            .swipeActions(edge: .leading) {
+                PinButton(
+                    itemID: file.id,
+                    courseID: course.id,
+                    type: .file
+                )
+            }
         } else {
             Label("File not available.", systemImage: "document")
         }

--- a/CanvasPlusPlayground/Features/Navigation/HomeView.swift
+++ b/CanvasPlusPlayground/Features/Navigation/HomeView.swift
@@ -81,7 +81,7 @@ struct HomeView: View {
             switch selectedNavigationPage {
             case .announcements: Text("All Announcements")
             case .toDoList: AggregatedAssignmentsView()
-            case .pinned: Text("Pinned Items")
+            case .pinned: PinnedItemsView()
             default: EmptyView()
             }
         } else {

--- a/CanvasPlusPlayground/Features/Pinned Items/PinButton.swift
+++ b/CanvasPlusPlayground/Features/Pinned Items/PinButton.swift
@@ -23,13 +23,13 @@ struct PinButton: View {
     var body: some View {
         Button(
             isItemPinned ? "Unpin" : "Pin",
-            systemImage: isItemPinned ? "unpin" : "pin"
+            systemImage: isItemPinned ? "pin.slash" : "pin"
         ) {
             pinnedItemsManager
                 .togglePinnedItem(
                     itemID: itemID,
                     courseID: courseID,
-                    type: .announcement
+                    type: type
                 )
         }
         .tint(.orange)

--- a/CanvasPlusPlayground/Features/Pinned Items/PinButton.swift
+++ b/CanvasPlusPlayground/Features/Pinned Items/PinButton.swift
@@ -1,0 +1,37 @@
+//
+//  PinButton.swift
+//  CanvasPlusPlayground
+//
+//  Created by Rahul on 1/9/25.
+//
+
+import SwiftUI
+
+struct PinButton: View {
+    @Environment(PinnedItemsManager.self) private var pinnedItemsManager
+
+    let itemID: String
+    let courseID: String
+    let type: PinnedItem.PinnedItemType
+
+    var isItemPinned: Bool {
+        pinnedItemsManager.pinnedItems.contains {
+            $0.id == itemID && $0.courseID == courseID && $0.type == type
+        }
+    }
+
+    var body: some View {
+        Button(
+            isItemPinned ? "Unpin" : "Pin",
+            systemImage: isItemPinned ? "unpin" : "pin"
+        ) {
+            pinnedItemsManager
+                .togglePinnedItem(
+                    itemID: itemID,
+                    courseID: courseID,
+                    type: .announcement
+                )
+        }
+        .tint(.orange)
+    }
+}

--- a/CanvasPlusPlayground/Features/Pinned Items/PinnedItem.swift
+++ b/CanvasPlusPlayground/Features/Pinned Items/PinnedItem.swift
@@ -1,0 +1,60 @@
+//
+//  PinnedItem.swift
+//  CanvasPlusPlayground
+//
+//  Created by Rahul on 1/9/25.
+//
+
+import Foundation
+
+struct PinnedItem: Identifiable, Codable {
+    let id: String
+    let courseID: String
+    let type: PinnedItemType
+
+    enum PinnedItemType: String, Codable {
+        case announcement, assignment, file
+        // TODO: Add more pinned item types
+    }
+
+    func itemData() async -> PinnedItemData? {
+        do {
+            return try await fetchData()
+        } catch {
+            print("Error fetching \(type): \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    private func fetchData() async throws -> PinnedItemData? {
+        switch type {
+        case .announcement:
+            let announcements = try await CanvasService.shared.loadAndSync(
+                CanvasRequest.getAnnouncements(courseId: courseID)
+            )
+            guard let announcement = announcements.first(where: { $0.id == id }) else { return nil }
+            return .announcement(announcement)
+
+        case .assignment:
+            let assignments = try await CanvasService.shared.fetch(
+                CanvasRequest.getAssignment(id: id, courseId: courseID)
+            )
+            guard let assignment = assignments.first else { return nil }
+            return .assignment(assignment)
+
+        case .file:
+            let files = try await CanvasService.shared.loadAndSync(
+                CanvasRequest.getFile(fileId: id)
+            )
+            guard let file = files.first else { return nil }
+            return .file(file)
+        }
+    }
+}
+
+enum PinnedItemData {
+    case announcement(Announcement)
+    case assignment(AssignmentAPI)
+    case file(File)
+    // TODO: Add more pinned item types
+}

--- a/CanvasPlusPlayground/Features/Pinned Items/PinnedItemCard.swift
+++ b/CanvasPlusPlayground/Features/Pinned Items/PinnedItemCard.swift
@@ -1,0 +1,102 @@
+//
+//  PinnedItemCard.swift
+//  CanvasPlusPlayground
+//
+//  Created by Rahul on 1/10/25.
+//
+
+import SwiftUI
+
+struct PinnedItemCard: View {
+    let item: PinnedItem
+
+    var body: some View {
+        AsyncView {
+            await item.itemData()
+        } content: { itemData in
+            switch itemData.modelData {
+            case .announcement(let announcement):
+                PinnedAnnouncementCard(
+                    announcement: announcement,
+                    course: itemData.course
+                )
+            case .file(let file):
+                PinnedFileCard(
+                    file: file,
+                    course: itemData.course
+                )
+            default: Text("Got \(itemData)")
+            }
+        } placeholder: {
+            Text("Loading...")
+        }
+    }
+}
+
+struct PinnedAnnouncementCard: View {
+    let announcement: Announcement
+    let course: Course
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(course.displayName.uppercased())
+                .font(.caption)
+                .foregroundStyle(course.rgbColors?.color ?? .accentColor)
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text(announcement.title ?? "")
+                    .font(.headline)
+                    .fontDesign(.rounded)
+                    .bold()
+
+                Text(
+                    announcement.message?
+                        .stripHTML()
+                        .trimmingCharacters(
+                            in: .whitespacesAndNewlines
+                        )
+                    ?? ""
+                )
+                .lineLimit(2)
+            }
+        }
+        .cardBackground()
+    }
+}
+
+struct PinnedFileCard: View {
+    let file: File
+    let course: Course
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "document")
+                .foregroundStyle(course.rgbColors?.color ?? .accentColor)
+                .font(.title)
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text(course.displayName.uppercased())
+                    .font(.caption)
+                    .foregroundStyle(course.rgbColors?.color ?? .accentColor)
+
+                Text(file.displayName)
+                    .font(.headline)
+                    .fontDesign(.rounded)
+                    .bold()
+            }
+        }
+        .cardBackground()
+    }
+}
+
+extension View {
+    fileprivate func cardBackground() -> some View {
+        self
+            .frame(width: 250)
+            .padding(12)
+            .background {
+                RoundedRectangle(cornerRadius: 16.0)
+                    .fill(.secondary.opacity(0.15))
+            }
+    }
+}

--- a/CanvasPlusPlayground/Features/Pinned Items/PinnedItemCard.swift
+++ b/CanvasPlusPlayground/Features/Pinned Items/PinnedItemCard.swift
@@ -25,7 +25,11 @@ struct PinnedItemCard: View {
                     file: file,
                     course: itemData.course
                 )
-            default: Text("Got \(itemData)")
+            case .assignment(let assignment):
+                PinnedAssignmentCard(
+                    assignment: assignment,
+                    course: itemData.course
+                )
             }
         } placeholder: {
             Text("Loading...")
@@ -81,6 +85,33 @@ private struct PinnedFileCard: View {
                     .foregroundStyle(course.rgbColors?.color ?? .accentColor)
 
                 Text(file.displayName)
+                    .font(.headline)
+                    .fontDesign(.rounded)
+                    .bold()
+            }
+
+            Spacer()
+        }
+        .cardBackground()
+    }
+}
+
+private struct PinnedAssignmentCard: View {
+    let assignment: AssignmentAPI
+    let course: Course
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "circle")
+                .foregroundStyle(course.rgbColors?.color ?? .accentColor)
+                .font(.title)
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text(course.displayName.uppercased())
+                    .font(.caption)
+                    .foregroundStyle(course.rgbColors?.color ?? .accentColor)
+
+                Text(assignment.name)
                     .font(.headline)
                     .fontDesign(.rounded)
                     .bold()

--- a/CanvasPlusPlayground/Features/Pinned Items/PinnedItemCard.swift
+++ b/CanvasPlusPlayground/Features/Pinned Items/PinnedItemCard.swift
@@ -30,10 +30,11 @@ struct PinnedItemCard: View {
         } placeholder: {
             Text("Loading...")
         }
+        .buttonStyle(.plain)
     }
 }
 
-struct PinnedAnnouncementCard: View {
+private struct PinnedAnnouncementCard: View {
     let announcement: Announcement
     let course: Course
 
@@ -64,7 +65,7 @@ struct PinnedAnnouncementCard: View {
     }
 }
 
-struct PinnedFileCard: View {
+private struct PinnedFileCard: View {
     let file: File
     let course: Course
 
@@ -84,6 +85,8 @@ struct PinnedFileCard: View {
                     .fontDesign(.rounded)
                     .bold()
             }
+
+            Spacer()
         }
         .cardBackground()
     }
@@ -93,6 +96,7 @@ extension View {
     fileprivate func cardBackground() -> some View {
         self
             .frame(width: 250)
+            .frame(maxHeight: .infinity)
             .padding(12)
             .background {
                 RoundedRectangle(cornerRadius: 16.0)

--- a/CanvasPlusPlayground/Features/Pinned Items/PinnedItemsManager.swift
+++ b/CanvasPlusPlayground/Features/Pinned Items/PinnedItemsManager.swift
@@ -55,7 +55,7 @@ enum PinnedItemData {
 
 @Observable
 class PinnedItemsManager {
-    var pinnedItems: [PinnedItem] {
+    private(set) var pinnedItems: [PinnedItem] {
         get {
             access(keyPath: \.pinnedItems)
 
@@ -72,5 +72,43 @@ class PinnedItemsManager {
                 UserDefaults.standard.set(data, forKey: "pinnedItems")
             }
         }
+    }
+
+    func togglePinnedItem(
+        itemID: String,
+        courseID: String,
+        type: PinnedItem.PinnedItemType
+    ) {
+        if pinnedItems.contains(where: {
+            $0.id == itemID && $0.courseID == courseID && $0.type == type
+        }) {
+            removePinnedItem(itemID: itemID, courseID: courseID, type: type)
+        } else {
+            addPinnedItem(itemID: itemID, courseID: courseID, type: type)
+        }
+    }
+
+    func addPinnedItem(
+        itemID: String,
+        courseID: String,
+        type: PinnedItem.PinnedItemType
+    ) {
+        pinnedItems.append(
+            PinnedItem(id: itemID, courseID: courseID, type: type)
+        )
+    }
+
+    func removePinnedItem(
+        itemID: String,
+        courseID: String,
+        type: PinnedItem.PinnedItemType
+    ) {
+        let index = pinnedItems.firstIndex {
+            $0.id == itemID && $0.courseID == courseID && $0.type == type
+        }
+
+        guard let index else { return }
+
+        pinnedItems.remove(at: index)
     }
 }

--- a/CanvasPlusPlayground/Features/Pinned Items/PinnedItemsManager.swift
+++ b/CanvasPlusPlayground/Features/Pinned Items/PinnedItemsManager.swift
@@ -55,24 +55,15 @@ enum PinnedItemData {
 
 @Observable
 class PinnedItemsManager {
-    private(set) var pinnedItems: [PinnedItem] {
-        get {
-            access(keyPath: \.pinnedItems)
-
-            if let data = UserDefaults.standard.data(forKey: "pinnedItems") {
-                return (try? JSONDecoder().decode([PinnedItem].self, from: data)) ?? []
-            }
-
-            return []
-        }
-        set {
-            access(keyPath: \.pinnedItems)
-
-            if let data = try? JSONEncoder().encode(newValue) {
-                UserDefaults.standard.set(data, forKey: "pinnedItems")
-            }
-        }
+    private(set) var pinnedItems: [PinnedItem] = [] {
+        didSet { savePinnedItems() }
     }
+
+    init() {
+        getPinnedItems()
+    }
+
+    // MARK: - User Intents
 
     func togglePinnedItem(
         itemID: String,
@@ -110,5 +101,23 @@ class PinnedItemsManager {
         guard let index else { return }
 
         pinnedItems.remove(at: index)
+    }
+
+    // MARK: - Private
+
+    func savePinnedItems() {
+        if let data = try? JSONEncoder().encode(pinnedItems) {
+            UserDefaults.standard.set(data, forKey: "pinnedItems")
+        }
+    }
+
+    func getPinnedItems() {
+        var result: [PinnedItem] = []
+
+        if let data = UserDefaults.standard.data(forKey: "pinnedItems") {
+            result = (try? JSONDecoder().decode([PinnedItem].self, from: data)) ?? []
+        }
+
+        pinnedItems = result
     }
 }

--- a/CanvasPlusPlayground/Features/Pinned Items/PinnedItemsManager.swift
+++ b/CanvasPlusPlayground/Features/Pinned Items/PinnedItemsManager.swift
@@ -15,6 +15,10 @@ class PinnedItemsManager {
         didSet { savePinnedItems() }
     }
 
+    var pinnedItemsByType: [PinnedItem.PinnedItemType: [PinnedItem]] {
+        Dictionary(grouping: pinnedItems) { $0.type }
+    }
+
     init() {
         getPinnedItems()
     }

--- a/CanvasPlusPlayground/Features/Pinned Items/PinnedItemsManager.swift
+++ b/CanvasPlusPlayground/Features/Pinned Items/PinnedItemsManager.swift
@@ -65,13 +65,13 @@ class PinnedItemsManager {
 
     // MARK: - Private
 
-    func savePinnedItems() {
+    private func savePinnedItems() {
         if let data = try? JSONEncoder().encode(pinnedItems) {
             UserDefaults.standard.set(data, forKey: Self.pinnedItemsKey)
         }
     }
 
-    func getPinnedItems() {
+    private func getPinnedItems() {
         var result: [PinnedItem] = []
 
         if let data = UserDefaults.standard.data(forKey: Self.pinnedItemsKey) {

--- a/CanvasPlusPlayground/Features/Pinned Items/PinnedItemsManager.swift
+++ b/CanvasPlusPlayground/Features/Pinned Items/PinnedItemsManager.swift
@@ -1,0 +1,76 @@
+//
+//  PinnedItemsManager.swift
+//  CanvasPlusPlayground
+//
+//  Created by Rahul on 1/8/25.
+//
+
+import SwiftUI
+
+struct PinnedItem: Identifiable, Codable {
+    let id: String
+    let courseID: String
+    let type: PinnedItemType
+
+    enum PinnedItemType: String, Codable {
+        case announcement, assignment, file
+    }
+
+    func itemData() async -> PinnedItemData? {
+        do {
+            switch type {
+            case .announcement:
+                let announcements = try await CanvasService.shared.loadAndSync(
+                    CanvasRequest.getAnnouncements(courseId: courseID)
+                )
+                if let announcement = announcements.first(where: { $0.id == id }) {
+                    return .announcement(announcement)
+                }
+            case .assignment:
+                if let assignment = try await CanvasService.shared.fetch(
+                    CanvasRequest.getAssignment(id: id, courseId: courseID)
+                ).first {
+                    return .assignment(assignment)
+                }
+            case .file:
+                if let file = try await CanvasService.shared.loadAndSync(
+                    CanvasRequest.getFile(fileId: id)
+                ).first {
+                    return .file(file)
+                }
+            }
+        } catch {
+            print("Error fetching \(type): \(error.localizedDescription)")
+        }
+
+        return nil
+    }
+}
+
+enum PinnedItemData {
+    case announcement(Announcement)
+    case assignment(AssignmentAPI)
+    case file(File)
+}
+
+@Observable
+class PinnedItemsManager {
+    var pinnedItems: [PinnedItem] {
+        get {
+            access(keyPath: \.pinnedItems)
+
+            if let data = UserDefaults.standard.data(forKey: "pinnedItems") {
+                return (try? JSONDecoder().decode([PinnedItem].self, from: data)) ?? []
+            }
+
+            return []
+        }
+        set {
+            access(keyPath: \.pinnedItems)
+
+            if let data = try? JSONEncoder().encode(newValue) {
+                UserDefaults.standard.set(data, forKey: "pinnedItems")
+            }
+        }
+    }
+}

--- a/CanvasPlusPlayground/Features/Pinned Items/PinnedItemsView.swift
+++ b/CanvasPlusPlayground/Features/Pinned Items/PinnedItemsView.swift
@@ -22,8 +22,10 @@ struct PinnedItemsView: View {
                 ScrollView(.horizontal, showsIndicators: false) {
                     LazyHGrid(
                         rows: .init(
-                            repeating: .init(.flexible(minimum: 100, maximum: 400)),
-                            count: min(3, items.count)
+                            repeating: .init(
+                                .flexible(maximum: 400)
+                            ),
+                            count: min(2, items.count)
                         )
                     ) {
                         ForEach(items) { item in

--- a/CanvasPlusPlayground/Features/Pinned Items/PinnedItemsView.swift
+++ b/CanvasPlusPlayground/Features/Pinned Items/PinnedItemsView.swift
@@ -18,15 +18,22 @@ struct PinnedItemsView: View {
     var body: some View {
         List(sortedTypes, id: \.self) { type in
             Section {
+                let items = pinnedItemsManager.pinnedItemsByType[type] ?? []
                 ScrollView(.horizontal, showsIndicators: false) {
-                    HStack {
-                        ForEach(pinnedItemsManager.pinnedItemsByType[type] ?? []) { item in
+                    LazyHGrid(
+                        rows: .init(
+                            repeating: .init(.flexible(minimum: 100, maximum: 400)),
+                            count: min(3, items.count)
+                        )
+                    ) {
+                        ForEach(items) { item in
                             PinnedItemCard(item: item)
                         }
                     }
                 }
                 .scrollTargetBehavior(.paging)
                 .listRowSeparator(.hidden)
+                .fixedSize(horizontal: false, vertical: true)
 
             } header: {
                 Text(type.displayName)
@@ -37,65 +44,9 @@ struct PinnedItemsView: View {
             }
 
         }
+        .navigationTitle("Pinned")
         #if os(macOS)
         .navigationSplitViewColumnWidth(min: 350, ideal: 400)
         #endif
-    }
-}
-
-struct PinnedItemCard: View {
-    let item: PinnedItem
-
-    var body: some View {
-        AsyncView {
-            await item.itemData()
-        } content: { itemData in
-            switch itemData.modelData {
-            case .announcement(let announcement):
-                PinnedAnnouncementCard(
-                    announcement: announcement,
-                    course: itemData.course
-                )
-            default: Text("Got \(itemData)")
-            }
-        } placeholder: {
-            Text("Loading...")
-        }
-    }
-}
-
-struct PinnedAnnouncementCard: View {
-    let announcement: Announcement
-    let course: Course
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text(course.displayName.uppercased())
-                .font(.caption)
-                .foregroundStyle(course.rgbColors?.color ?? .accentColor)
-
-            VStack(alignment: .leading, spacing: 3) {
-                Text(announcement.title ?? "")
-                    .font(.headline)
-                    .fontDesign(.rounded)
-                    .bold()
-
-                Text(
-                    announcement.message?
-                        .stripHTML()
-                        .trimmingCharacters(
-                            in: .whitespacesAndNewlines
-                        )
-                    ?? ""
-                )
-                .lineLimit(2)
-            }
-        }
-        .frame(width: 250)
-        .padding(12)
-        .background {
-            RoundedRectangle(cornerRadius: 16.0)
-                .fill(.secondary.opacity(0.3))
-        }
     }
 }

--- a/CanvasPlusPlayground/Features/Pinned Items/PinnedItemsView.swift
+++ b/CanvasPlusPlayground/Features/Pinned Items/PinnedItemsView.swift
@@ -1,0 +1,24 @@
+//
+//  PinnedItemsView.swift
+//  CanvasPlusPlayground
+//
+//  Created by Rahul on 1/8/25.
+//
+
+import SwiftUI
+
+struct PinnedItemsView: View {
+    @Environment(PinnedItemsManager.self) private var pinnedItemsManager
+
+    var body: some View {
+        List(pinnedItemsManager.pinnedItems) { item in
+            AsyncView {
+                await item.itemData()
+            } content: { itemData in
+                Text("Got Data: \(itemData)")
+            } placeholder: {
+                Text("Loading...")
+            }
+        }
+    }
+}

--- a/CanvasPlusPlayground/Features/Pinned Items/PinnedItemsView.swift
+++ b/CanvasPlusPlayground/Features/Pinned Items/PinnedItemsView.swift
@@ -15,10 +15,39 @@ struct PinnedItemsView: View {
             AsyncView {
                 await item.itemData()
             } content: { itemData in
-                Text("Got Data: \(itemData)")
+                switch itemData {
+                case .announcement(let announcement):
+                    PinnedAnnouncementCard(announcement: announcement)
+                default: Text("Got \(itemData)")
+                }
             } placeholder: {
                 Text("Loading...")
             }
+        }
+        #if os(macOS)
+        .navigationSplitViewColumnWidth(min: 350, ideal: 400)
+        #endif
+    }
+}
+
+struct PinnedAnnouncementCard: View {
+    let announcement: Announcement
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            Text(announcement.title ?? "")
+                .font(.headline)
+                .bold()
+            Text(
+                announcement.message?
+                    .stripHTML()
+                    .trimmingCharacters(
+                        in: .whitespacesAndNewlines
+                    )
+                ?? ""
+            )
+            .font(.body)
+            .lineLimit(2)
         }
     }
 }

--- a/CanvasPlusPlayground/Features/Pinned Items/PinnedItemsView.swift
+++ b/CanvasPlusPlayground/Features/Pinned Items/PinnedItemsView.swift
@@ -65,5 +65,7 @@ struct PinnedItemsView: View {
         .scrollTargetBehavior(.paging)
         .listRowSeparator(.hidden)
         .fixedSize(horizontal: false, vertical: true)
+        .listRowInsets(EdgeInsets())
+        .contentMargins(.horizontal, 24, for: .scrollContent)
     }
 }

--- a/CanvasPlusPlayground/Features/Pinned Items/PinnedItemsView.swift
+++ b/CanvasPlusPlayground/Features/Pinned Items/PinnedItemsView.swift
@@ -32,6 +32,17 @@ struct PinnedItemsView: View {
         #if os(macOS)
         .navigationSplitViewColumnWidth(min: 350, ideal: 400)
         #endif
+        .overlay {
+            if sortedTypes.isEmpty {
+                ContentUnavailableView(
+                    "No Pinned Items",
+                    systemImage: "pin.fill",
+                    description: Text(
+                        "Pin files, assignments, announcements, and more from across all your courses for quick access."
+                    )
+                )
+            }
+        }
     }
 
     @ViewBuilder

--- a/CanvasPlusPlayground/Features/Pinned Items/PinnedItemsView.swift
+++ b/CanvasPlusPlayground/Features/Pinned Items/PinnedItemsView.swift
@@ -10,19 +10,32 @@ import SwiftUI
 struct PinnedItemsView: View {
     @Environment(PinnedItemsManager.self) private var pinnedItemsManager
 
+    private var sortedTypes: [PinnedItem.PinnedItemType] {
+        Array(pinnedItemsManager.pinnedItemsByType.keys)
+            .sorted(by: { $0.rawValue < $1.rawValue })
+    }
+
     var body: some View {
-        List(pinnedItemsManager.pinnedItems) { item in
-            AsyncView {
-                await item.itemData()
-            } content: { itemData in
-                switch itemData {
-                case .announcement(let announcement):
-                    PinnedAnnouncementCard(announcement: announcement)
-                default: Text("Got \(itemData)")
+        List(sortedTypes, id: \.self) { type in
+            Section {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack {
+                        ForEach(pinnedItemsManager.pinnedItemsByType[type] ?? []) { item in
+                            PinnedItemCard(item: item)
+                        }
+                    }
                 }
-            } placeholder: {
-                Text("Loading...")
+                .scrollTargetBehavior(.paging)
+                .listRowSeparator(.hidden)
+
+            } header: {
+                Text(type.displayName)
+                    .font(.title)
+                    .fontDesign(.rounded)
+                    .foregroundStyle(.tint)
+                    .bold()
             }
+
         }
         #if os(macOS)
         .navigationSplitViewColumnWidth(min: 350, ideal: 400)
@@ -30,24 +43,59 @@ struct PinnedItemsView: View {
     }
 }
 
-struct PinnedAnnouncementCard: View {
-    let announcement: Announcement
+struct PinnedItemCard: View {
+    let item: PinnedItem
 
     var body: some View {
-        VStack(alignment: .leading) {
-            Text(announcement.title ?? "")
-                .font(.headline)
-                .bold()
-            Text(
-                announcement.message?
-                    .stripHTML()
-                    .trimmingCharacters(
-                        in: .whitespacesAndNewlines
-                    )
-                ?? ""
-            )
-            .font(.body)
-            .lineLimit(2)
+        AsyncView {
+            await item.itemData()
+        } content: { itemData in
+            switch itemData.modelData {
+            case .announcement(let announcement):
+                PinnedAnnouncementCard(
+                    announcement: announcement,
+                    course: itemData.course
+                )
+            default: Text("Got \(itemData)")
+            }
+        } placeholder: {
+            Text("Loading...")
+        }
+    }
+}
+
+struct PinnedAnnouncementCard: View {
+    let announcement: Announcement
+    let course: Course
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(course.displayName.uppercased())
+                .font(.caption)
+                .foregroundStyle(course.rgbColors?.color ?? .accentColor)
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text(announcement.title ?? "")
+                    .font(.headline)
+                    .fontDesign(.rounded)
+                    .bold()
+
+                Text(
+                    announcement.message?
+                        .stripHTML()
+                        .trimmingCharacters(
+                            in: .whitespacesAndNewlines
+                        )
+                    ?? ""
+                )
+                .lineLimit(2)
+            }
+        }
+        .frame(width: 250)
+        .padding(12)
+        .background {
+            RoundedRectangle(cornerRadius: 16.0)
+                .fill(.secondary.opacity(0.3))
         }
     }
 }

--- a/CanvasPlusPlayground/Features/Pinned Items/PinnedItemsView.swift
+++ b/CanvasPlusPlayground/Features/Pinned Items/PinnedItemsView.swift
@@ -18,25 +18,7 @@ struct PinnedItemsView: View {
     var body: some View {
         List(sortedTypes, id: \.self) { type in
             Section {
-                let items = pinnedItemsManager.pinnedItemsByType[type] ?? []
-                ScrollView(.horizontal, showsIndicators: false) {
-                    LazyHGrid(
-                        rows: .init(
-                            repeating: .init(
-                                .flexible(maximum: 400)
-                            ),
-                            count: min(2, items.count)
-                        )
-                    ) {
-                        ForEach(items) { item in
-                            PinnedItemCard(item: item)
-                        }
-                    }
-                }
-                .scrollTargetBehavior(.paging)
-                .listRowSeparator(.hidden)
-                .fixedSize(horizontal: false, vertical: true)
-
+                sectionContent(for: type)
             } header: {
                 Text(type.displayName)
                     .font(.title)
@@ -50,5 +32,27 @@ struct PinnedItemsView: View {
         #if os(macOS)
         .navigationSplitViewColumnWidth(min: 350, ideal: 400)
         #endif
+    }
+
+    @ViewBuilder
+    private func sectionContent(for type: PinnedItem.PinnedItemType) -> some View {
+        let items = pinnedItemsManager.pinnedItemsByType[type] ?? []
+        ScrollView(.horizontal, showsIndicators: false) {
+            LazyHGrid(
+                rows: .init(
+                    repeating: .init(
+                        .flexible(maximum: 400)
+                    ),
+                    count: min(2, items.count)
+                )
+            ) {
+                ForEach(items) { item in
+                    PinnedItemCard(item: item)
+                }
+            }
+        }
+        .scrollTargetBehavior(.paging)
+        .listRowSeparator(.hidden)
+        .fixedSize(horizontal: false, vertical: true)
     }
 }

--- a/CanvasPlusPlayground/Features/Settings/SettingsView.swift
+++ b/CanvasPlusPlayground/Features/Settings/SettingsView.swift
@@ -8,6 +8,9 @@
 import SwiftUI
 
 struct SettingsView: View {
+    #if DEBUG
+    @Environment(PinnedItemsManager.self) private var pinnedItemManager
+    #endif
     @Environment(NavigationModel.self) private var navigationModel
     @EnvironmentObject private var llmEvaluator: LLMEvaluator
     @EnvironmentObject private var intelligenceManager: IntelligenceManager
@@ -94,10 +97,15 @@ struct SettingsView: View {
         #endif
     }
 
+    #if DEBUG
     private var debugSettings: some View {
         Section {
             Group {
-                Button("Clear cache", systemImage: "opticaldiscdrive") {
+                Button("Clear Pinned Items", systemImage: "trash") {
+                    pinnedItemManager.clearAllPinnedItems()
+                }
+
+                Button("Clear Cache", systemImage: "opticaldiscdrive") {
                     CanvasService.shared.clearStorage()
                 }
 
@@ -118,6 +126,7 @@ struct SettingsView: View {
             Label("Debug", systemImage: "ant")
         }
     }
+    #endif
 }
 
 #Preview {


### PR DESCRIPTION
Fixes #170.

## Changes Made

- Implement Pinned Items model and view. Currently allows users to pin any assignment, file, or announcement.
- Implement requests to fetch single files and assignments. Announcements does not support this.
- Next: Click on a pinned item in a the pinned items view to directly see that item.

## Screenshots (if applicable)

<img width="300" alt="Simulator Screenshot - iPhone 16 Pro - 2025-01-10 at 20 08 19" src="https://github.com/user-attachments/assets/351dc761-5a93-497a-9c53-55cc06148333" />
<img width="500" alt="Screenshot 2025-01-10 at 8 08 35 PM" src="https://github.com/user-attachments/assets/48f6a6f3-e64e-4c47-80f5-f893469301fe" />


