### PR TITLE
Fix Duplicate ID crash

### DIFF
--- a/CanvasPlusPlayground/Common/Network/APIRequest+Sync.swift
+++ b/CanvasPlusPlayground/Common/Network/APIRequest+Sync.swift
@@ -85,6 +85,8 @@ extension CacheableAPIRequest {
             }
         }
 
+        try repository.modelContext.save()
+
         return latest
     }
 

--- a/CanvasPlusPlayground/Common/Network/APIRequest+Sync.swift
+++ b/CanvasPlusPlayground/Common/Network/APIRequest+Sync.swift
@@ -61,14 +61,15 @@ extension CacheableAPIRequest {
         var latest: [PersistedModel] = try await {
 
             // Adjust `fetch` generic parameter based on whether request is for a collection.
-            let fetched: [PersistedModel]
+            var fetched: [PersistedModel] = []
             if QueryResult.self is any Collection.Type {
-                fetched = try await fetch(onNewPage: { batch in
+                _ = try await fetch(onNewPage: { batch in
                     let batchAsModel = batch.map { $0.createModel() }
                     let transformed = await updateStorage(batchAsModel)
 
+                    fetched += transformed
                     onNewBatch(transformed)
-                }).map { $0.createModel() }
+                })
             } else {
                 let responseAsModel = try await fetch().map { $0.createModel() }
                 fetched = await updateStorage(responseAsModel)


### PR DESCRIPTION
No issue for this.

## Changes Made

- Save `modelContext` after every sync to keep memory aligned with storage - avoid duplicates.
- Remove redundant mapping for model creation.

## Screenshots (if applicable)

https://github.com/user-attachments/assets/1d7d5b84-3e7f-4773-ab62-3e5fc090945d
