### PR TITLE
Optional Pagination, Support for Direct Page Fetch

### DIFF
--- a/CanvasPlusPlayground.xcodeproj/project.pbxproj
+++ b/CanvasPlusPlayground.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		A351913F2D283556001E415F /* ModulesListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A351913E2D283556001E415F /* ModulesListView.swift */; };
 		A35191412D283589001E415F /* ModulesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A35191402D283589001E415F /* ModulesViewModel.swift */; };
 		A35191432D28ED48001E415F /* GetModuleItemsRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = A35191422D28ED48001E415F /* GetModuleItemsRequest.swift */; };
+		A352AD182D3DA423007EE6FC /* LoadingMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = A352AD172D3DA423007EE6FC /* LoadingMethod.swift */; };
 		A373DC0D2D19F65700215019 /* APIGradingPeriod.swift in Sources */ = {isa = PBXBuildFile; fileRef = A373DC0C2D19F65700215019 /* APIGradingPeriod.swift */; };
 		A373DC0F2D19F71600215019 /* TypeSafeCodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = A373DC0E2D19F71600215019 /* TypeSafeCodable.swift */; };
 		A373DC142D19FA2A00215019 /* APICourseSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = A373DC132D19FA2A00215019 /* APICourseSection.swift */; };
@@ -186,6 +187,7 @@
 		A351913E2D283556001E415F /* ModulesListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModulesListView.swift; sourceTree = "<group>"; };
 		A35191402D283589001E415F /* ModulesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModulesViewModel.swift; sourceTree = "<group>"; };
 		A35191422D28ED48001E415F /* GetModuleItemsRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetModuleItemsRequest.swift; sourceTree = "<group>"; };
+		A352AD172D3DA423007EE6FC /* LoadingMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingMethod.swift; sourceTree = "<group>"; };
 		A373DC0C2D19F65700215019 /* APIGradingPeriod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIGradingPeriod.swift; sourceTree = "<group>"; };
 		A373DC0E2D19F71600215019 /* TypeSafeCodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypeSafeCodable.swift; sourceTree = "<group>"; };
 		A373DC132D19FA2A00215019 /* APICourseSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APICourseSection.swift; sourceTree = "<group>"; };
@@ -422,6 +424,7 @@
 				A3049B732D15DBEE002F3166 /* API Requests */,
 				A3E7F38A2C9555B200DC4300 /* CanvasService.swift */,
 				A3FFD03D2CE0065A006BAB51 /* NetworkError.swift */,
+				A352AD172D3DA423007EE6FC /* LoadingMethod.swift */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -772,6 +775,7 @@
 				192EC04A2C963B9000AF8528 /* AssignmentAPI.swift in Sources */,
 				A3049B722D125509002F3166 /* APIRequest.swift in Sources */,
 				A373DC0D2D19F65700215019 /* APIGradingPeriod.swift in Sources */,
+				A352AD182D3DA423007EE6FC /* LoadingMethod.swift in Sources */,
 				A3E59D362CF271C000AF91BD /* Predicate+Extensions.swift in Sources */,
 				B7926D162CE95CED00BFFBE1 /* RGBColors.swift in Sources */,
 				3DAE84FE2C9A0CE8008C22E7 /* CoursePDFView.swift in Sources */,

--- a/CanvasPlusPlayground/Common/Network/APIRequest+Storage.swift
+++ b/CanvasPlusPlayground/Common/Network/APIRequest+Storage.swift
@@ -24,10 +24,16 @@ extension CacheableAPIRequest {
 
     /// Only loads from storage, doesn't make a network call
     @MainActor
-    func load(from repository: CanvasRepository) async throws -> [PersistedModel]? {
+    func load(from repository: CanvasRepository, loadingMethod: LoadingMethod<Self>) async throws -> [PersistedModel]? {
+        var descriptor = loadDescriptor
+
+        if case let .page(order) = loadingMethod {
+            descriptor.fetchOffset = self.perPage * (order - 1)
+            descriptor.fetchLimit = self.perPage
+        }
 
         // Get cached data for this type then filter to only get models related to `request`
-        let cached: [PersistedModel]? = try repository.get(descriptor: loadDescriptor)
+        let cached: [PersistedModel]? = try repository.get(descriptor: descriptor)
 
         return cached
     }

--- a/CanvasPlusPlayground/Common/Network/APIRequest+Sync.swift
+++ b/CanvasPlusPlayground/Common/Network/APIRequest+Sync.swift
@@ -15,7 +15,7 @@ extension CacheableAPIRequest {
         onNewBatch: ([PersistedModel]) -> Void = { _ in },
         loadingMethod: LoadingMethod<Self> = .all(onNewPage: { _ in })
     ) async throws -> [PersistedModel] {
-        let cached = try await load(from: repository) ?? []
+        let cached = try await load(from: repository, loadingMethod: loadingMethod) ?? []
 
         return try await syncWithAPI(
             to: repository,
@@ -120,7 +120,10 @@ extension CacheableAPIRequest {
         loadingMethod: LoadingMethod<Self> = .all(onNewPage: { _ in })
     ) async throws -> [PersistedModel] {
 
-        let cached: [PersistedModel]? = try await load(from: repository)
+        let cached: [PersistedModel]? = try await load(
+            from: repository,
+            loadingMethod: loadingMethod
+        )
         onCacheReceive(cached) // Share cached version with caller.
 
         let latest = try await syncWithAPI(

--- a/CanvasPlusPlayground/Common/Network/APIRequest+Sync.swift
+++ b/CanvasPlusPlayground/Common/Network/APIRequest+Sync.swift
@@ -75,6 +75,7 @@ extension CacheableAPIRequest {
 
                             fetched += transformed
                             onNewPage(transformed)
+                            onNewBatch(transformed) // TODO: remove once loadingMethod is fully integrated
                         }
                     )
                 } else {

--- a/CanvasPlusPlayground/Common/Network/APIRequest+Sync.swift
+++ b/CanvasPlusPlayground/Common/Network/APIRequest+Sync.swift
@@ -33,7 +33,7 @@ extension CacheableAPIRequest {
         loadingMethod: LoadingMethod<Self>
     ) async throws -> [PersistedModel] {
 
-        let cacheLookup = Dictionary(uniqueKeysWithValues: cache.map { ($0.id, $0) })
+        let cacheLookup = Dictionary(uniqueKeysWithValues: Set(cache).map { ($0.id, $0) })
 
         let updateStorage: ([PersistedModel]) async -> [PersistedModel] = { newModels in
             // New batch received

--- a/CanvasPlusPlayground/Common/Network/APIRequest.swift
+++ b/CanvasPlusPlayground/Common/Network/APIRequest.swift
@@ -16,6 +16,7 @@ protocol APIRequest {
     var path: String { get }
     var queryParameters: [QueryParameter] { get }
     var method: RequestMethod { get }
+    var perPage: Int { get }
 }
 
 extension APIRequest {
@@ -42,6 +43,8 @@ extension APIRequest {
     }
 
     var method: RequestMethod { .GET }
+
+    var perPage: Int { 50 }
 }
 
 protocol ArrayAPIRequest: APIRequest {

--- a/CanvasPlusPlayground/Common/Network/CanvasService.swift
+++ b/CanvasPlusPlayground/Common/Network/CanvasService.swift
@@ -79,12 +79,12 @@ class CanvasService {
 
     // MARK: Network Requests
 
-    func fetchResponse<Request: APIRequest>(_ request: Request) async throws -> (data: Data, response: URLResponse) {
+    func fetchResponse<Request: APIRequest>(_ request: Request) async throws -> (data: Data, url: URLResponse) {
         return try await request.fetchResponse()
     }
 
-    func fetch<Request: APIRequest>(_ request: Request) async throws -> [Request.Subject] {
-        return try await request.fetch()
+    func fetch<Request: APIRequest>(_ request: Request, loadingMethod: LoadingMethod<Request> = .all(onNewPage: {_ in})) async throws -> [Request.Subject] {
+        return try await request.fetch(loadingMethod: loadingMethod)
     }
 
     // MARK: Repository actions

--- a/CanvasPlusPlayground/Common/Network/CanvasService.swift
+++ b/CanvasPlusPlayground/Common/Network/CanvasService.swift
@@ -20,7 +20,7 @@ class CanvasService {
 
     /// Only loads from storage, doesn't make a network call
     @MainActor
-    func load<Request: CacheableAPIRequest>(_ request: Request, loadingMethod: LoadingMethod<Request>) async throws -> [Request.PersistedModel]? {
+    func load<Request: CacheableAPIRequest>(_ request: Request, loadingMethod: LoadingMethod<Request> = .all(onNewPage: { _ in})) async throws -> [Request.PersistedModel]? {
         guard let repository else { return nil }
 
         // Get cached data for this type then filter to only get models related to `request`
@@ -45,7 +45,7 @@ class CanvasService {
     func syncWithAPI<Request: CacheableAPIRequest>(
         _ request: Request,
         onNewBatch: ([Request.PersistedModel]) -> Void = { _ in },
-        loadingMethod: LoadingMethod<Request>
+        loadingMethod: LoadingMethod<Request> = .all(onNewPage: { _ in})
     ) async throws -> [Request.PersistedModel] {
         guard let repository else { return [] }
 
@@ -74,7 +74,7 @@ class CanvasService {
         _ request: Request,
         onCacheReceive: ([Request.PersistedModel]?) -> Void = { _ in },
         onNewBatch: ([Request.PersistedModel]) -> Void = { _ in },
-        loadingMethod: LoadingMethod<Request>
+        loadingMethod: LoadingMethod<Request> = .all(onNewPage: { _ in})
     ) async throws -> [Request.PersistedModel] {
         guard let repository else { return [] }
 

--- a/CanvasPlusPlayground/Common/Network/LoadingMethod.swift
+++ b/CanvasPlusPlayground/Common/Network/LoadingMethod.swift
@@ -1,0 +1,12 @@
+//
+//  LoadingMethod.swift
+//  CanvasPlusPlayground
+//
+//  Created by Abdulaziz Albahar on 1/19/25.
+//
+
+import Foundation
+
+enum LoadingMethod<R: APIRequest> {
+    case page(order: Int), all(onNewPage: ([R.Subject.Model]) -> Void)
+}

--- a/CanvasPlusPlayground/Common/Network/LoadingMethod.swift
+++ b/CanvasPlusPlayground/Common/Network/LoadingMethod.swift
@@ -8,5 +8,6 @@
 import Foundation
 
 enum LoadingMethod<R: APIRequest> {
+    /// page `order` must be > 1
     case page(order: Int), all(onNewPage: ([R.Subject.Model]) -> Void)
 }


### PR DESCRIPTION
Fixes #174 

## Changes Made
- Created `LoadingMethod` enum to describe two ways of fetching data: by fetching all data at endpoint page by page OR by fetching a single page when desired. Allows for paginated `List` loading.
- Integrated loading method into different layers while maintaining old functionality.
- Made `perPage` a global request field with a default of `50`. Since we need to calculate the page offset when loading from storage.

## Screenshots (if applicable)

