### PR TITLE
Implement Profiles

### DIFF
--- a/CanvasPlusPlayground.xcodeproj/project.pbxproj
+++ b/CanvasPlusPlayground.xcodeproj/project.pbxproj
@@ -97,6 +97,7 @@
 		B533C0BE2CADDDE700A74AF6 /* PeopleCommonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B533C0BD2CADDDE700A74AF6 /* PeopleCommonView.swift */; };
 		B53D95A02CA0953900647EE9 /* PeopleManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53D959F2CA0952F00647EE9 /* PeopleManager.swift */; };
 		B53D95A22CA0A22A00647EE9 /* PeopleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53D95A12CA0A22A00647EE9 /* PeopleView.swift */; };
+		B73AE0BD2D4FB68B007094A8 /* Profile.swift in Sources */ = {isa = PBXBuildFile; fileRef = B73AE0BC2D4FB68B007094A8 /* Profile.swift */; };
 		B76454FE2C8DF61B002DF00E /* Course.swift in Sources */ = {isa = PBXBuildFile; fileRef = B76454ED2C8DF61B002DF00E /* Course.swift */; };
 		B76454FF2C8DF61B002DF00E /* Enrollment.swift in Sources */ = {isa = PBXBuildFile; fileRef = B76454EE2C8DF61B002DF00E /* Enrollment.swift */; };
 		B76455002C8DF61B002DF00E /* File.swift in Sources */ = {isa = PBXBuildFile; fileRef = B76454EF2C8DF61B002DF00E /* File.swift */; };
@@ -110,6 +111,7 @@
 		B76455082C8DF61B002DF00E /* CourseManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B76454FC2C8DF61B002DF00E /* CourseManager.swift */; };
 		B76455092C8DF61B002DF00E /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B76454F22C8DF61B002DF00E /* Preview Assets.xcassets */; };
 		B764550A2C8DF61B002DF00E /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B76454F92C8DF61B002DF00E /* Assets.xcassets */; };
+		B77FD0022D52A0D60049AA5E /* ProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B77FD0012D52A0D20049AA5E /* ProfileView.swift */; };
 		B785BE652CF592710094BF94 /* LLM in Frameworks */ = {isa = PBXBuildFile; productRef = B785BE642CF592710094BF94 /* LLM */; };
 		B7926D162CE95CED00BFFBE1 /* RGBColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7926D152CE95CE900BFFBE1 /* RGBColors.swift */; };
 		B7926D182CE962C200BFFBE1 /* ColorPickerWithoutLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7926D172CE962C200BFFBE1 /* ColorPickerWithoutLabel.swift */; };
@@ -236,6 +238,7 @@
 		B533C0BD2CADDDE700A74AF6 /* PeopleCommonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeopleCommonView.swift; sourceTree = "<group>"; };
 		B53D959F2CA0952F00647EE9 /* PeopleManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeopleManager.swift; sourceTree = "<group>"; };
 		B53D95A12CA0A22A00647EE9 /* PeopleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeopleView.swift; sourceTree = "<group>"; };
+		B73AE0BC2D4FB68B007094A8 /* Profile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Profile.swift; sourceTree = "<group>"; };
 		B76454642C8BBC7F002DF00E /* CanvasPlusPlayground.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CanvasPlusPlayground.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B76454ED2C8DF61B002DF00E /* Course.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Course.swift; sourceTree = "<group>"; };
 		B76454EE2C8DF61B002DF00E /* Enrollment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Enrollment.swift; sourceTree = "<group>"; };
@@ -250,6 +253,7 @@
 		B76454FA2C8DF61B002DF00E /* CanvasPlusPlaygroundApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanvasPlusPlaygroundApp.swift; sourceTree = "<group>"; };
 		B76454FB2C8DF61B002DF00E /* CourseFileViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseFileViewModel.swift; sourceTree = "<group>"; };
 		B76454FC2C8DF61B002DF00E /* CourseManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseManager.swift; sourceTree = "<group>"; };
+		B77FD0012D52A0D20049AA5E /* ProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileView.swift; sourceTree = "<group>"; };
 		B7926D152CE95CE900BFFBE1 /* RGBColors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RGBColors.swift; sourceTree = "<group>"; };
 		B7926D172CE962C200BFFBE1 /* ColorPickerWithoutLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorPickerWithoutLabel.swift; sourceTree = "<group>"; };
 		B7A26EE82CCB62A00084704A /* NavigationModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationModel.swift; sourceTree = "<group>"; };
@@ -704,6 +708,8 @@
 		B7F950352D12785D004BB470 /* Profile */ = {
 			isa = PBXGroup;
 			children = (
+				B77FD0012D52A0D20049AA5E /* ProfileView.swift */,
+				B73AE0BC2D4FB68B007094A8 /* Profile.swift */,
 				B7F950362D127861004BB470 /* ProfileManager.swift */,
 				B7F9503A2D127AD0004BB470 /* ProfileAPI.swift */,
 			);
@@ -871,6 +877,7 @@
 				A3049B612D0E6110002F3166 /* QuizQuestionType.swift in Sources */,
 				A3CA025B2D432A8700A9752B /* SearchResultListDataSource.swift in Sources */,
 				9B9C2E042C93F6CD00E4B16B /* CourseAnnouncementsView.swift in Sources */,
+				B77FD0022D52A0D60049AA5E /* ProfileView.swift in Sources */,
 				192EC04C2C963EE600AF8528 /* CourseAssignmentView.swift in Sources */,
 				A3FFD03C2CDED67C006BAB51 /* String+Numbers.swift in Sources */,
 				B53D95A02CA0953900647EE9 /* PeopleManager.swift in Sources */,
@@ -914,6 +921,7 @@
 				A3D161512D178615004055FB /* GetUserProfileRequest.swift in Sources */,
 				A3D161492D169C23004055FB /* APIRequest+Storage.swift in Sources */,
 				9B6663E32C9853BC0060990E /* HTMLTextView.swift in Sources */,
+				B73AE0BD2D4FB68B007094A8 /* Profile.swift in Sources */,
 				B7AD550C2CD4257B00FB09BB /* IntelligenceOnboardingView.swift in Sources */,
 				B7D751312D3D688C00F7B8B8 /* AnnouncementRow.swift in Sources */,
 				A3049B792D15E162002F3166 /* GetCourseRootFolder.swift in Sources */,

--- a/CanvasPlusPlayground.xcodeproj/project.pbxproj
+++ b/CanvasPlusPlayground.xcodeproj/project.pbxproj
@@ -112,6 +112,7 @@
 		B76455092C8DF61B002DF00E /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B76454F22C8DF61B002DF00E /* Preview Assets.xcassets */; };
 		B764550A2C8DF61B002DF00E /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B76454F92C8DF61B002DF00E /* Assets.xcassets */; };
 		B77FD0022D52A0D60049AA5E /* ProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B77FD0012D52A0D20049AA5E /* ProfileView.swift */; };
+		B77FD0072D5309340049AA5E /* ProfilePicture.swift in Sources */ = {isa = PBXBuildFile; fileRef = B77FD0062D5309340049AA5E /* ProfilePicture.swift */; };
 		B785BE652CF592710094BF94 /* LLM in Frameworks */ = {isa = PBXBuildFile; productRef = B785BE642CF592710094BF94 /* LLM */; };
 		B7926D162CE95CED00BFFBE1 /* RGBColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7926D152CE95CE900BFFBE1 /* RGBColors.swift */; };
 		B7926D182CE962C200BFFBE1 /* ColorPickerWithoutLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7926D172CE962C200BFFBE1 /* ColorPickerWithoutLabel.swift */; };
@@ -254,6 +255,7 @@
 		B76454FB2C8DF61B002DF00E /* CourseFileViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseFileViewModel.swift; sourceTree = "<group>"; };
 		B76454FC2C8DF61B002DF00E /* CourseManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseManager.swift; sourceTree = "<group>"; };
 		B77FD0012D52A0D20049AA5E /* ProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileView.swift; sourceTree = "<group>"; };
+		B77FD0062D5309340049AA5E /* ProfilePicture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfilePicture.swift; sourceTree = "<group>"; };
 		B7926D152CE95CE900BFFBE1 /* RGBColors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RGBColors.swift; sourceTree = "<group>"; };
 		B7926D172CE962C200BFFBE1 /* ColorPickerWithoutLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorPickerWithoutLabel.swift; sourceTree = "<group>"; };
 		B7A26EE82CCB62A00084704A /* NavigationModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationModel.swift; sourceTree = "<group>"; };
@@ -708,6 +710,7 @@
 		B7F950352D12785D004BB470 /* Profile */ = {
 			isa = PBXGroup;
 			children = (
+				B77FD0062D5309340049AA5E /* ProfilePicture.swift */,
 				B77FD0012D52A0D20049AA5E /* ProfileView.swift */,
 				B73AE0BC2D4FB68B007094A8 /* Profile.swift */,
 				B7F950362D127861004BB470 /* ProfileManager.swift */,
@@ -887,6 +890,7 @@
 				B7D7512B2D3D5D8000F7B8B8 /* AllAnnouncementsView.swift in Sources */,
 				A3E7F3892C954E0500DC4300 /* CanvasRequest.swift in Sources */,
 				A352AD1A2D3EF1C1007EE6FC /* GetCourseUsersRequest.swift in Sources */,
+				B77FD0072D5309340049AA5E /* ProfilePicture.swift in Sources */,
 				A35191412D283589001E415F /* ModulesViewModel.swift in Sources */,
 				A3E7F3912C99317100DC4300 /* CourseTabsManager.swift in Sources */,
 				A3E7F38F2C96C1CE00DC4300 /* CourseTabsView.swift in Sources */,

--- a/CanvasPlusPlayground/Common/Components/Search Results/SearchResultsListView.swift
+++ b/CanvasPlusPlayground/Common/Components/Search Results/SearchResultsListView.swift
@@ -8,15 +8,41 @@
 import SwiftUI
 
 /// Inspired by https://medium.engineering/how-to-do-pagination-in-swiftui-04511be7fbd1
-struct SearchResultsListView<Content: View, DataSource: SearchResultListDataSource>: View {
+struct SearchResultsListView<
+    Content: View,
+    DataSource: SearchResultListDataSource,
+    SelectionItem: Hashable
+>: View {
+    enum SelectionValue {
+        case single(Binding<SelectionItem>)
+        case multi(Binding<Set<SelectionItem>>)
+    }
+
     @State var dataSource: DataSource
+    var selection: SelectionValue? = nil
     let itemsView: () -> Content
 
     init(
         dataSource: DataSource,
+        selection: Binding<SelectionItem>? = nil,
         itemsView: @escaping () -> Content
     ) {
         self._dataSource = State(initialValue: dataSource)
+        if let selection {
+            self.selection = .single(selection)
+        }
+        self.itemsView = itemsView
+    }
+
+    init(
+        dataSource: DataSource,
+        selection: Binding<Set<SelectionItem>>? = nil,
+        itemsView: @escaping () -> Content
+    ) {
+        self._dataSource = State(initialValue: dataSource)
+        if let selection {
+            self.selection = .multi(selection)
+        }
         self.itemsView = itemsView
     }
 
@@ -25,29 +51,46 @@ struct SearchResultsListView<Content: View, DataSource: SearchResultListDataSour
     }
 
     var listView: some View {
-        List {
-            itemsView()
-
-            if dataSource.queryMode == .offline {
-                offlineLabel
-            }
-
-            switch dataSource.loadingState {
-            case .nextPageReady:
-                Color.clear
-                    .onAppear {
-                        Task { await dataSource.fetchNextPage() }
-                    }
-            case .error(let reason):
-                errorView(for: reason)
-            case .idle, .loading:
-                EmptyView()
+        Group {
+            if case .single(let selection) = selection {
+                List(selection: selection) {
+                    listContent
+                }
+            } else if case .multi(let selection) = selection {
+                List(selection: selection) {
+                    listContent
+                }
+            } else {
+                List {
+                    listContent
+                }
             }
         }
         .statusToolbarItem(
             dataSource.label,
             isVisible: dataSource.loadingState == .loading
         )
+    }
+
+    @ViewBuilder
+    var listContent: some View {
+        itemsView()
+
+        if dataSource.queryMode == .offline {
+            offlineLabel
+        }
+
+        switch dataSource.loadingState {
+        case .nextPageReady:
+            Color.clear
+                .onAppear {
+                    Task { await dataSource.fetchNextPage() }
+                }
+        case .error(let reason):
+            errorView(for: reason)
+        case .idle, .loading:
+            EmptyView()
+        }
     }
 
     func errorView(for reason: String) -> some View {

--- a/CanvasPlusPlayground/Common/Components/Search Results/SearchResultsListView.swift
+++ b/CanvasPlusPlayground/Common/Components/Search Results/SearchResultsListView.swift
@@ -8,41 +8,15 @@
 import SwiftUI
 
 /// Inspired by https://medium.engineering/how-to-do-pagination-in-swiftui-04511be7fbd1
-struct SearchResultsListView<
-    Content: View,
-    DataSource: SearchResultListDataSource,
-    SelectionItem: Hashable
->: View {
-    enum SelectionValue {
-        case single(Binding<SelectionItem>)
-        case multi(Binding<Set<SelectionItem>>)
-    }
-
+struct SearchResultsListView<Content: View, DataSource: SearchResultListDataSource>: View {
     @State var dataSource: DataSource
-    var selection: SelectionValue? = nil
     let itemsView: () -> Content
 
     init(
         dataSource: DataSource,
-        selection: Binding<SelectionItem>? = nil,
         itemsView: @escaping () -> Content
     ) {
         self._dataSource = State(initialValue: dataSource)
-        if let selection {
-            self.selection = .single(selection)
-        }
-        self.itemsView = itemsView
-    }
-
-    init(
-        dataSource: DataSource,
-        selection: Binding<Set<SelectionItem>>? = nil,
-        itemsView: @escaping () -> Content
-    ) {
-        self._dataSource = State(initialValue: dataSource)
-        if let selection {
-            self.selection = .multi(selection)
-        }
         self.itemsView = itemsView
     }
 
@@ -51,46 +25,29 @@ struct SearchResultsListView<
     }
 
     var listView: some View {
-        Group {
-            if case .single(let selection) = selection {
-                List(selection: selection) {
-                    listContent
-                }
-            } else if case .multi(let selection) = selection {
-                List(selection: selection) {
-                    listContent
-                }
-            } else {
-                List {
-                    listContent
-                }
+        List {
+            itemsView()
+
+            if dataSource.queryMode == .offline {
+                offlineLabel
+            }
+
+            switch dataSource.loadingState {
+            case .nextPageReady:
+                Color.clear
+                    .onAppear {
+                        Task { await dataSource.fetchNextPage() }
+                    }
+            case .error(let reason):
+                errorView(for: reason)
+            case .idle, .loading:
+                EmptyView()
             }
         }
         .statusToolbarItem(
             dataSource.label,
             isVisible: dataSource.loadingState == .loading
         )
-    }
-
-    @ViewBuilder
-    var listContent: some View {
-        itemsView()
-
-        if dataSource.queryMode == .offline {
-            offlineLabel
-        }
-
-        switch dataSource.loadingState {
-        case .nextPageReady:
-            Color.clear
-                .onAppear {
-                    Task { await dataSource.fetchNextPage() }
-                }
-        case .error(let reason):
-            errorView(for: reason)
-        case .idle, .loading:
-            EmptyView()
-        }
     }
 
     func errorView(for reason: String) -> some View {

--- a/CanvasPlusPlayground/Common/Network/API Requests/GetCourseUsersRequest.swift
+++ b/CanvasPlusPlayground/Common/Network/API Requests/GetCourseUsersRequest.swift
@@ -20,7 +20,7 @@ struct GetCourseUsersRequest: CacheableArrayAPIRequest {
             ("user_id", userId),
             ("per_page", perPage)
         ]
-        + include.map { ("include[]", $0) }
+        + include.map { ("include[]", $0.rawValue) }
         + enrollmentType.map { ("enrollment_type[]", $0.asFilter) }
         + userIds.map { ("user_ids[]", $0) }
         + enrollmentState.map { ("enrollment_state", $0) }
@@ -70,9 +70,15 @@ struct GetCourseUsersRequest: CacheableArrayAPIRequest {
 
 extension GetCourseUsersRequest {
     enum Include: String {
-        case enrollments = "enrollments", locked, avatarUrl = "avatar_url", bio, testStudent = "test_student",
+        case enrollments = "enrollments",
+             locked,
+             avatarUrl = "avatar_url",
+             bio,
+             testStudent = "test_student",
              customLinks = "custom_links",
-             currentGradingPeriodScores = "current_grading_period_scores", uuid
+             currentGradingPeriodScores = "current_grading_period_scores",
+             uuid,
+             pronouns
     }
 
     enum Sorter: String {

--- a/CanvasPlusPlayground/Common/Network/API Requests/GetUserProfileRequest.swift
+++ b/CanvasPlusPlayground/Common/Network/API Requests/GetUserProfileRequest.swift
@@ -7,14 +7,29 @@
 
 import Foundation
 
-/// Pass in `nil` as `userID` to fetch the current user.
-struct GetUserProfileRequest: APIRequest {
+struct GetUserProfileRequest: CacheableAPIRequest {
     typealias Subject = ProfileAPI
 
-    let userId: String?
+    let userId: String
     var queryParameters: [QueryParameter] {
         []
     }
 
-    var path: String { "users/\(userId ?? "self")/profile" }
+    /// Pass in `nil` as `userID` to fetch the current user profile.
+    init(userId: String? = nil) {
+        self.userId = userId ?? "self"
+    }
+
+    var path: String { "users/\(userId)/profile" }
+
+    var requestId: String { userId }
+    var requestIdKey: ParentKeyPath<Profile, String> { .createWritable(\.tag) }
+    var idPredicate: Predicate<Profile> {
+        #Predicate<Profile> { profile in
+            profile.tag == userId
+        }
+    }
+    var customPredicate: Predicate<Profile> {
+        .true
+    }
 }

--- a/CanvasPlusPlayground/Common/Network/API Requests/GetUserRequest.swift
+++ b/CanvasPlusPlayground/Common/Network/API Requests/GetUserRequest.swift
@@ -7,14 +7,29 @@
 
 import Foundation
 
-/// Pass in `nil` as `userID` to fetch the current user.
-struct GetUserRequest: APIRequest {
+struct GetUserRequest: CacheableAPIRequest {
     typealias Subject = UserAPI
 
-    let userId: String?
+    let userId: String
     var queryParameters: [QueryParameter] {
         []
     }
 
-    var path: String { "users/\(userId ?? "self")" }
+    /// Pass in `nil` as `userID` to fetch the current user.
+    init(userId: String? = nil) {
+        self.userId = userId ?? "self"
+    }
+
+    var path: String { "users/\(userId)" }
+
+    var requestId: String { userId }
+    var requestIdKey: ParentKeyPath<User, String> { .createWritable(\.tag) }
+    var idPredicate: Predicate<User> {
+        #Predicate<User> { user in
+            user.tag == userId
+        }
+    }
+    var customPredicate: Predicate<User> {
+        .true
+    }
 }

--- a/CanvasPlusPlayground/Common/Storage/CanvasRepository.swift
+++ b/CanvasPlusPlayground/Common/Storage/CanvasRepository.swift
@@ -23,7 +23,8 @@ class CanvasRepository {
             Module.self,
             ModuleItem.self,
             Submission.self,
-            User.self
+            User.self,
+            Profile.self
             // TODO: Add cacheable models here
         )
         self.modelContext = ModelContext(modelContainer)

--- a/CanvasPlusPlayground/Features/Grades/GradesViewModel.swift
+++ b/CanvasPlusPlayground/Features/Grades/GradesViewModel.swift
@@ -41,8 +41,8 @@ class GradesViewModel {
         self.courseId = courseId
     }
 
-    func getEnrollments(currentUserID: Int?) async {
-        guard let currentUserID else {
+    func getEnrollments(currentUserID: String?) async {
+        guard let currentUserID = currentUserID?.asInt else {
             print("GradesViewModel: Current UserID is nil.")
             return
         }

--- a/CanvasPlusPlayground/Features/Navigation/HomeView.swift
+++ b/CanvasPlusPlayground/Features/Navigation/HomeView.swift
@@ -82,7 +82,6 @@ struct HomeView: View {
                 NavigationStack {
                     ProfileView(
                         user: currentUser,
-                        profile: profileManager.currentProfile,
                         showCommonCourses: false
                     )
                 }

--- a/CanvasPlusPlayground/Features/Navigation/HomeView.swift
+++ b/CanvasPlusPlayground/Features/Navigation/HomeView.swift
@@ -77,6 +77,16 @@ struct HomeView: View {
             }
             .interactiveDismissDisabled()
         }
+        .sheet(isPresented: $navigationModel.showProfileSheet, content: {
+            if let currentUser = profileManager.currentUser {
+                NavigationStack {
+                    ProfileView(user: currentUser)
+                }
+                #if os(macOS)
+                .frame(width: 400, height: 400)
+                #endif
+            }
+        })
         #if os(iOS)
         .sheet(isPresented: $navigationModel.showSettingsSheet) {
             SettingsView()

--- a/CanvasPlusPlayground/Features/Navigation/HomeView.swift
+++ b/CanvasPlusPlayground/Features/Navigation/HomeView.swift
@@ -77,13 +77,17 @@ struct HomeView: View {
             }
             .interactiveDismissDisabled()
         }
-        .sheet(isPresented: $navigationModel.showProfileSheet, content: {
+        .sheet(isPresented: $navigationModel.showProfileSheet) {
             if let currentUser = profileManager.currentUser {
                 NavigationStack {
-                    ProfileView(user: currentUser, showCommonCourses: false)
+                    ProfileView(
+                        user: currentUser,
+                        profile: profileManager.currentProfile,
+                        showCommonCourses: false
+                    )
                 }
             }
-        })
+        }
         #if os(iOS)
         .sheet(isPresented: $navigationModel.showSettingsSheet) {
             SettingsView()

--- a/CanvasPlusPlayground/Features/Navigation/HomeView.swift
+++ b/CanvasPlusPlayground/Features/Navigation/HomeView.swift
@@ -80,11 +80,8 @@ struct HomeView: View {
         .sheet(isPresented: $navigationModel.showProfileSheet, content: {
             if let currentUser = profileManager.currentUser {
                 NavigationStack {
-                    ProfileView(user: currentUser)
+                    ProfileView(user: currentUser, showCommonCourses: false)
                 }
-                #if os(macOS)
-                .frame(width: 400, height: 400)
-                #endif
             }
         })
         #if os(iOS)

--- a/CanvasPlusPlayground/Features/Navigation/NavigationModel.swift
+++ b/CanvasPlusPlayground/Features/Navigation/NavigationModel.swift
@@ -77,6 +77,7 @@ class NavigationModel {
     var selectedCoursePage: CoursePage?
     var showInstallIntelligenceSheet = false
     var showAuthorizationSheet = false
+    var showProfileSheet = false
     #if os(iOS)
     var showSettingsSheet = false
     #endif

--- a/CanvasPlusPlayground/Features/Navigation/Sidebar.swift
+++ b/CanvasPlusPlayground/Features/Navigation/Sidebar.swift
@@ -74,6 +74,7 @@ struct Sidebar: View {
                 Button("Profile", systemImage: "person.circle") {
                     navigationModel.showProfileSheet.toggle()
                 }
+                .disabled(profileManager.currentUser == nil)
             }
         }
     }

--- a/CanvasPlusPlayground/Features/Navigation/Sidebar.swift
+++ b/CanvasPlusPlayground/Features/Navigation/Sidebar.swift
@@ -71,10 +71,18 @@ struct Sidebar: View {
         #endif
         .toolbar {
             ToolbarItem(placement: .confirmationAction) {
-                Button("Profile", systemImage: "person.circle") {
-                    navigationModel.showProfileSheet.toggle()
+                if let currentUser = profileManager.currentUser {
+                    Button {
+                        navigationModel.showProfileSheet.toggle()
+                    } label: {
+                        ProfilePicture(user: currentUser)
+                        #if os(macOS)
+                            .frame(width: 19, height: 19)
+                        #else
+                            .frame(width: 24, height: 24)
+                        #endif
+                    }
                 }
-                .disabled(profileManager.currentUser == nil)
             }
         }
     }

--- a/CanvasPlusPlayground/Features/Navigation/Sidebar.swift
+++ b/CanvasPlusPlayground/Features/Navigation/Sidebar.swift
@@ -69,6 +69,13 @@ struct Sidebar: View {
             }
         }
         #endif
+        .toolbar {
+            ToolbarItem(placement: .secondaryAction) {
+                Button("Profile", systemImage: "person.circle") {
+                    navigationModel.showProfileSheet.toggle()
+                }
+            }
+        }
     }
 }
 

--- a/CanvasPlusPlayground/Features/Navigation/Sidebar.swift
+++ b/CanvasPlusPlayground/Features/Navigation/Sidebar.swift
@@ -70,7 +70,7 @@ struct Sidebar: View {
         }
         #endif
         .toolbar {
-            ToolbarItem(placement: .secondaryAction) {
+            ToolbarItem(placement: .confirmationAction) {
                 Button("Profile", systemImage: "person.circle") {
                     navigationModel.showProfileSheet.toggle()
                 }

--- a/CanvasPlusPlayground/Features/People/Models/User.swift
+++ b/CanvasPlusPlayground/Features/People/Models/User.swift
@@ -35,6 +35,7 @@ class User: Cacheable {
 
     // MARK: Custom
     var courseId: String?
+    var tag: String
 
     init(from userAPI: UserAPI) {
         self.id = String(userAPI.id)
@@ -46,6 +47,7 @@ class User: Cacheable {
         self.pronouns = userAPI.pronouns
         self.role = userAPI.role
         self.enrollments = userAPI.enrollments ?? []
+        self.tag = ""
     }
 
     func merge(with other: User) {

--- a/CanvasPlusPlayground/Features/People/Models/User.swift
+++ b/CanvasPlusPlayground/Features/People/Models/User.swift
@@ -36,6 +36,7 @@ class User: Cacheable {
     // MARK: Custom
     var courseId: String?
     var tag: String
+    var avatarImageData: Data?
 
     init(from userAPI: UserAPI) {
         self.id = String(userAPI.id)
@@ -61,6 +62,11 @@ class User: Cacheable {
         self.enrollments = other.enrollments
     }
 
+    var hasAvatar: Bool {
+        guard let avatarURL else { return false }
+
+        return !avatarURL.absoluteString.hasSuffix("avatar-50.png")
+    }
 }
 
 enum EnrollmentType: String, CaseIterable {

--- a/CanvasPlusPlayground/Features/People/PeopleCommonView.swift
+++ b/CanvasPlusPlayground/Features/People/PeopleCommonView.swift
@@ -8,7 +8,6 @@
 import SwiftUI
 
 struct PeopleCommonView: View {
-    @Environment(PeopleManager.self) var peopleManager
     @Environment(CourseManager.self) var courseManager
     let user: User
 
@@ -16,7 +15,7 @@ struct PeopleCommonView: View {
     @State private var fetchingCommonCourses: Bool = false
 
     var body: some View {
-        Form {
+        Group {
             Section {
                 statusLabel
             } footer: {
@@ -64,7 +63,7 @@ struct PeopleCommonView: View {
         let id = user.id
 
         fetchingCommonCourses = true
-        await peopleManager
+        await PeopleManager
             .fetchAllClassesWith(
                 userID: id,
                 activeCourses: courseManager.displayedCourses

--- a/CanvasPlusPlayground/Features/People/PeopleManager.swift
+++ b/CanvasPlusPlayground/Features/People/PeopleManager.swift
@@ -59,7 +59,7 @@ class PeopleManager: SearchResultListDataSource {
 
         let request = CanvasRequest.getUsers(
             courseId: courseID,
-            include: [.enrollments],
+            include: [.enrollments, .avatarUrl, .bio, .pronouns],
             searchTerm: searchText.count >= 2 ? searchText : "",
             enrollmentType: selectedRoles,
             perPage: 60

--- a/CanvasPlusPlayground/Features/People/PeopleManager.swift
+++ b/CanvasPlusPlayground/Features/People/PeopleManager.swift
@@ -122,7 +122,7 @@ class PeopleManager: SearchResultListDataSource {
 
 // MARK: Shared Classes Feature
 extension PeopleManager {
-    func fetchAllClassesWith(
+    static func fetchAllClassesWith(
         userID: String,
         activeCourses courses: [Course],
         receivedNewCourse: @escaping (Course) -> Void = { _ in }

--- a/CanvasPlusPlayground/Features/People/PeopleView.swift
+++ b/CanvasPlusPlayground/Features/People/PeopleView.swift
@@ -116,8 +116,6 @@ struct PeopleView: View {
 private struct UserCell: View {
     let user: User
 
-    static let height: CGFloat = 25 // Only works on MacOS
-
     init(for user: User) {
         self.user = user
     }
@@ -125,18 +123,20 @@ private struct UserCell: View {
     var body: some View {
         NavigationLink(value: user) {
             HStack {
-                Text(user.name)
-                    .font(.headline)
-                Spacer()
-                Text(
-                    user.enrollmentRoles
-                        .map(\.displayName)
-                        .joined(separator: ", ")
-                )
-                .foregroundStyle(.secondary)
+                ProfilePicture(user: user)
+                    .frame(width: 35, height: 35)
+
+                VStack(alignment: .leading) {
+                    Text(user.name)
+                    Text(
+                        user.enrollmentRoles
+                            .map(\.displayName)
+                            .joined(separator: ", ")
+                    )
+                    .foregroundStyle(.secondary)
+                }
             }
         }
-        .frame(height: Self.height)
     }
 }
 

--- a/CanvasPlusPlayground/Features/People/PeopleView.swift
+++ b/CanvasPlusPlayground/Features/People/PeopleView.swift
@@ -144,16 +144,19 @@ private struct UserCell: View {
 
     var body: some View {
         HStack {
-            if #available(iOS 18.0, *) {
-                ProfilePicture(user: user)
-                    .frame(width: 35, height: 35)
-                    #if os(iOS)
-                    .matchedTransitionSource(id: user.id, in: namespace)
-                    #endif
-            } else {
-                ProfilePicture(user: user)
-                    .frame(width: 35, height: 35)
+            Group {
+                if #available(iOS 18.0, *) {
+                    ProfilePicture(user: user)
+                        .frame(width: 35, height: 35)
+                        #if os(iOS)
+                        .matchedTransitionSource(id: user.id, in: namespace)
+                        #endif
+                } else {
+                    ProfilePicture(user: user)
+                        .frame(width: 35, height: 35)
+                }
             }
+            .symbolVariant(.fill)
 
             VStack(alignment: .leading) {
                 Text(user.name)

--- a/CanvasPlusPlayground/Features/People/PeopleView.swift
+++ b/CanvasPlusPlayground/Features/People/PeopleView.swift
@@ -19,6 +19,8 @@ struct PeopleView: View {
     @State private var selectedTokens: [Token] = []
     @State private var searchText: String = ""
 
+    @State private var selectedUser: User?
+
     @State private var currentSearchTask: Task<Void, Never>?
 
     private var suggestedTokens: [Token] {
@@ -43,14 +45,18 @@ struct PeopleView: View {
     }
 
     private var mainBody: some View {
-        SearchResultsListView(dataSource: peopleManager) {
+        SearchResultsListView(
+            dataSource: peopleManager,
+            selection: $selectedUser
+        ) {
             ForEach(peopleManager.displayedUsers, id: \.id) { user in
                 UserCell(for: user)
+                    .tag(user)
             }
         }
         .navigationTitle("People")
-        .navigationDestination(for: User.self) { user in
-            PeopleCommonView(user: user).environment(peopleManager)
+        .sheet(item: $selectedUser) { user in
+            ProfileView(user: user)
         }
         #if os(iOS)
         .searchable(
@@ -121,20 +127,18 @@ private struct UserCell: View {
     }
 
     var body: some View {
-        NavigationLink(value: user) {
-            HStack {
-                ProfilePicture(user: user)
-                    .frame(width: 35, height: 35)
+        HStack {
+            ProfilePicture(user: user)
+                .frame(width: 35, height: 35)
 
-                VStack(alignment: .leading) {
-                    Text(user.name)
-                    Text(
-                        user.enrollmentRoles
-                            .map(\.displayName)
-                            .joined(separator: ", ")
-                    )
-                    .foregroundStyle(.secondary)
-                }
+            VStack(alignment: .leading) {
+                Text(user.name)
+                Text(
+                    user.enrollmentRoles
+                        .map(\.displayName)
+                        .joined(separator: ", ")
+                )
+                .foregroundStyle(.secondary)
             }
         }
     }

--- a/CanvasPlusPlayground/Features/People/PeopleView.swift
+++ b/CanvasPlusPlayground/Features/People/PeopleView.swift
@@ -42,22 +42,22 @@ struct PeopleView: View {
             currentSearchTask?.cancel()
             await newQuery() // don't use `newQueryAsync` to allow the refresh animation to persist until query finished
         }
+        .sheet(item: $selectedUser) { user in
+            NavigationStack {
+                ProfileView(user: user)
+            }
+        }
     }
 
     private var mainBody: some View {
         SearchResultsListView(
-            dataSource: peopleManager,
-            selection: $selectedUser
+            dataSource: peopleManager
         ) {
             ForEach(peopleManager.displayedUsers, id: \.id) { user in
-                UserCell(for: user)
-                    .tag(user)
+                UserCell(user: user, selectedUser: $selectedUser)
             }
         }
         .navigationTitle("People")
-        .sheet(item: $selectedUser) { user in
-            ProfileView(user: user)
-        }
         #if os(iOS)
         .searchable(
             text: $searchText,
@@ -121,10 +121,7 @@ struct PeopleView: View {
 
 private struct UserCell: View {
     let user: User
-
-    init(for user: User) {
-        self.user = user
-    }
+    @Binding var selectedUser: User?
 
     var body: some View {
         HStack {
@@ -139,6 +136,14 @@ private struct UserCell: View {
                         .joined(separator: ", ")
                 )
                 .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            Button {
+                selectedUser = user
+            } label: {
+                Image(systemName: "info.circle")
             }
         }
     }

--- a/CanvasPlusPlayground/Features/Profile/Profile.swift
+++ b/CanvasPlusPlayground/Features/Profile/Profile.swift
@@ -1,0 +1,74 @@
+//
+//  Profile.swift
+//  CanvasPlusPlayground
+//
+//  Created by Rahul on 2/13/24.
+//
+
+import Foundation
+import SwiftData
+
+@Model
+class Profile: Cacheable {
+    typealias ID = String
+    typealias ServerID = Int
+
+    @Attribute(.unique)
+    let id: String
+    var name: String?
+    var shortName: String?
+    var sortableName: String?
+    var title: String?
+    var bio: String?
+    var pronunciation: String?
+    var primaryEmail: String?
+    var loginId: String?
+    var sisUserId: String?
+    var ltiUserId: String?
+    var avatarUrl: URL?
+    var timeZone: String?
+    var locale: String?
+    var isK5User: Bool?
+    var useClassicFontInK5: Bool?
+
+    // MARK: Custom
+    var tag: String
+
+    init(from profileAPI: ProfileAPI) {
+        self.id = String(profileAPI.id)
+        self.name = profileAPI.name
+        self.shortName = profileAPI.short_name
+        self.sortableName = profileAPI.sortable_name
+        self.title = profileAPI.title
+        self.bio = profileAPI.bio
+        self.pronunciation = profileAPI.pronunciation
+        self.primaryEmail = profileAPI.primary_email
+        self.loginId = profileAPI.login_id
+        self.sisUserId = profileAPI.sis_user_id
+        self.ltiUserId = profileAPI.lti_user_id
+        self.avatarUrl = profileAPI.avatar_url
+        self.timeZone = profileAPI.time_zone
+        self.locale = profileAPI.locale
+        self.isK5User = profileAPI.k5_user
+        self.useClassicFontInK5 = profileAPI.use_classic_font_in_k5
+        self.tag = ""
+    }
+
+    func merge(with other: Profile) {
+        self.name = other.name
+        self.shortName = other.shortName
+        self.sortableName = other.sortableName
+        self.title = other.title
+        self.bio = other.bio
+        self.pronunciation = other.pronunciation
+        self.primaryEmail = other.primaryEmail
+        self.loginId = other.loginId
+        self.sisUserId = other.sisUserId
+        self.ltiUserId = other.ltiUserId
+        self.avatarUrl = other.avatarUrl
+        self.timeZone = other.timeZone
+        self.locale = other.locale
+        self.isK5User = other.isK5User
+        self.useClassicFontInK5 = other.useClassicFontInK5
+    }
+}

--- a/CanvasPlusPlayground/Features/Profile/ProfileAPI.swift
+++ b/CanvasPlusPlayground/Features/Profile/ProfileAPI.swift
@@ -8,10 +8,10 @@
 import Foundation
 
 struct ProfileAPI: APIResponse {
-    typealias Model = NoOpCacheable
+    typealias Model = Profile
 
     // swiftlint:disable identifier_name
-    let id: Int?
+    let id: Int
     let name: String?
     let short_name: String?
     let sortable_name: String?
@@ -30,4 +30,7 @@ struct ProfileAPI: APIResponse {
     let use_classic_font_in_k5: Bool?
     // swiftlint:enable identifier_name
 
+    func createModel() -> Profile {
+        Profile(from: self)
+    }
 }

--- a/CanvasPlusPlayground/Features/Profile/ProfileManager.swift
+++ b/CanvasPlusPlayground/Features/Profile/ProfileManager.swift
@@ -9,26 +9,38 @@ import SwiftUI
 
 @Observable
 class ProfileManager {
-    private(set) var currentUser: UserAPI?
-    private(set) var currentProfile: ProfileAPI?
+    private(set) var currentUser: User?
+    private(set) var currentProfile: Profile?
 
     // MARK: - Methods
     func getCurrentUserAndProfile() async {
         do {
-            let user: UserAPI = try await CanvasService.shared.fetch(CanvasRequest.getUser())[0]
+            let user: User = try await CanvasService.shared.loadAndSync(CanvasRequest.getUser())[0]
             currentUser = user
         } catch {
             print("Error fetching current user: \(error)")
         }
 
         do {
-            let profile: ProfileAPI = try await CanvasService.shared.fetch(CanvasRequest.getUserProfile())[0]
+            let profile: Profile = try await CanvasService.shared.loadAndSync(CanvasRequest.getUserProfile())[0]
             currentProfile = profile
         } catch {
             print("Error fetching current user profile: \(error)")
         }
 
         print("Current user: \(currentUser?.name ?? "")")
-        print("Current user profile: \(currentProfile?.primary_email ?? "")")
+        print("Current user profile: \(currentProfile?.primaryEmail ?? "")")
+    }
+
+    func getProfile(for id: User.ID) async -> Profile? {
+        do {
+            let profile: Profile = try await CanvasService.shared.loadAndSync(CanvasRequest.getUserProfile(userId: id))[0]
+
+            return profile
+        } catch {
+            print("Error fetching user profile: \(error)")
+        }
+
+        return nil
     }
 }

--- a/CanvasPlusPlayground/Features/Profile/ProfileManager.swift
+++ b/CanvasPlusPlayground/Features/Profile/ProfileManager.swift
@@ -15,14 +15,20 @@ class ProfileManager {
     // MARK: - Methods
     func getCurrentUserAndProfile() async {
         do {
-            let user: User = try await CanvasService.shared.loadAndSync(CanvasRequest.getUser())[0]
+            let user: User = try await CanvasService.shared.loadAndSync(CanvasRequest.getUser(), onCacheReceive: { users in
+                currentUser = users?.first
+            })[0]
+
             currentUser = user
         } catch {
             print("Error fetching current user: \(error)")
         }
 
         do {
-            let profile: Profile = try await CanvasService.shared.loadAndSync(CanvasRequest.getUserProfile())[0]
+            let profile: Profile = try await CanvasService.shared.loadAndSync(CanvasRequest.getUserProfile(), onCacheReceive: { profiles in
+                currentProfile = profiles?.first
+            })[0]
+
             currentProfile = profile
         } catch {
             print("Error fetching current user profile: \(error)")

--- a/CanvasPlusPlayground/Features/Profile/ProfilePicture.swift
+++ b/CanvasPlusPlayground/Features/Profile/ProfilePicture.swift
@@ -7,23 +7,49 @@
 
 import SwiftUI
 
+#if os(macOS)
+private typealias PlatformImage = NSImage
+#else
+private typealias PlatformImage = UIImage
+#endif
+
 struct ProfilePicture: View {
     let user: User
 
     var body: some View {
-        AsyncImage(url: user.avatarURL) { image in
-            image
-                .resizable()
-                .clipShape(.circle)
-        } placeholder: {
-            Image(systemName: "person.circle.fill")
-                .resizable()
-                .foregroundColor(.gray)
+        Group {
+            if user.hasAvatar,
+                let imageData = user.avatarImageData,
+                let image = PlatformImage(data: imageData) {
+                #if os(macOS)
+                Image(nsImage: image)
+                    .resizable()
+                    .clipShape(.circle)
+                #else
+                Image(uiImage: image)
+                    .resizable()
+                    .clipShape(.circle)
+                #endif
+            } else {
+                Image(systemName: "person.circle.fill")
+                    .resizable()
+                    .foregroundColor(.gray)
+            }
         }
         .overlay {
             Circle()
                 .stroke(lineWidth: 1)
                 .fill(.separator)
+        }
+        .task {
+            guard user.hasAvatar, let url = user.avatarURL else { return }
+
+            do {
+                let (data, _) = try await URLSession.shared.data(from: url)
+                user.avatarImageData = data
+            } catch {
+                print("Error loading image: \(error)")
+            }
         }
     }
 }

--- a/CanvasPlusPlayground/Features/Profile/ProfilePicture.swift
+++ b/CanvasPlusPlayground/Features/Profile/ProfilePicture.swift
@@ -1,0 +1,29 @@
+//
+//  ProfilePicture.swift
+//  CanvasPlusPlayground
+//
+//  Created by Rahul on 2/4/25.
+//
+
+import SwiftUI
+
+struct ProfilePicture: View {
+    let user: User
+
+    var body: some View {
+        AsyncImage(url: user.avatarURL) { image in
+            image
+                .resizable()
+                .clipShape(.circle)
+        } placeholder: {
+            Image(systemName: "person.circle.fill")
+                .resizable()
+                .foregroundColor(.gray)
+        }
+        .overlay {
+            Circle()
+                .stroke(lineWidth: 1)
+                .fill(.separator)
+        }
+    }
+}

--- a/CanvasPlusPlayground/Features/Profile/ProfilePicture.swift
+++ b/CanvasPlusPlayground/Features/Profile/ProfilePicture.swift
@@ -33,7 +33,7 @@ struct ProfilePicture: View {
             } else {
                 Image(systemName: "person.circle.fill")
                     .resizable()
-                    .foregroundColor(.gray)
+                    .foregroundStyle(.tint)
             }
         }
         .overlay {

--- a/CanvasPlusPlayground/Features/Profile/ProfilePicture.swift
+++ b/CanvasPlusPlayground/Features/Profile/ProfilePicture.swift
@@ -31,7 +31,7 @@ struct ProfilePicture: View {
                     .clipShape(.circle)
                 #endif
             } else {
-                Image(systemName: "person.circle.fill")
+                Image(systemName: "person.circle")
                     .resizable()
                     .foregroundStyle(.tint)
             }

--- a/CanvasPlusPlayground/Features/Profile/ProfileView.swift
+++ b/CanvasPlusPlayground/Features/Profile/ProfileView.swift
@@ -14,16 +14,20 @@ struct ProfileView: View {
     let user: User
     var showCommonCourses: Bool = true
 
-    @State private var profile: Profile? // needed to get email for curr user
+    var profile: Profile? {
+        if user.id == profileManager.currentUser?.id {
+            return profileManager.currentProfile
+        }
+
+        return nil
+    }
 
     init(
         user: User,
-        profile: Profile? = nil,
         showCommonCourses: Bool = true
     ) {
         self.user = user
         self.showCommonCourses = showCommonCourses
-        self.profile = profile
     }
 
     var body: some View {
@@ -40,11 +44,6 @@ struct ProfileView: View {
             }
         }
         .formStyle(.grouped)
-        .task {
-            if profile == nil {
-                profile = await profileManager.getProfile(for: user.id)
-            }
-        }
         .toolbar {
             ToolbarItem(placement: .confirmationAction) {
                 Button("Done") {

--- a/CanvasPlusPlayground/Features/Profile/ProfileView.swift
+++ b/CanvasPlusPlayground/Features/Profile/ProfileView.swift
@@ -63,6 +63,7 @@ struct ProfileView: View {
             VStack {
                 ProfilePicture(user: user)
                     .frame(width: 100, height: 100)
+                    .symbolVariant(.fill)
 
                 VStack(alignment: .center) {
                     Text(user.name)

--- a/CanvasPlusPlayground/Features/Profile/ProfileView.swift
+++ b/CanvasPlusPlayground/Features/Profile/ProfileView.swift
@@ -16,6 +16,16 @@ struct ProfileView: View {
 
     @State private var profile: Profile? // needed to get email for curr user
 
+    init(
+        user: User,
+        profile: Profile? = nil,
+        showCommonCourses: Bool = true
+    ) {
+        self.user = user
+        self.showCommonCourses = showCommonCourses
+        self.profile = profile
+    }
+
     var body: some View {
         Form {
             Section {
@@ -31,7 +41,9 @@ struct ProfileView: View {
         }
         .formStyle(.grouped)
         .task {
-            profile = await profileManager.getProfile(for: user.id)
+            if profile == nil {
+                profile = await profileManager.getProfile(for: user.id)
+            }
         }
         .toolbar {
             ToolbarItem(placement: .confirmationAction) {

--- a/CanvasPlusPlayground/Features/Profile/ProfileView.swift
+++ b/CanvasPlusPlayground/Features/Profile/ProfileView.swift
@@ -12,6 +12,8 @@ struct ProfileView: View {
     @Environment(\.dismiss) private var dismiss
 
     let user: User
+    var showCommonCourses: Bool = true
+
     @State private var profile: Profile? // needed to get email for curr user
 
     var body: some View {
@@ -22,6 +24,10 @@ struct ProfileView: View {
             }
 
             details
+
+            if showCommonCourses {
+                PeopleCommonView(user: user)
+            }
         }
         .formStyle(.grouped)
         .task {
@@ -35,6 +41,9 @@ struct ProfileView: View {
             }
         }
         .animation(.default, value: profile)
+        #if os(macOS)
+        .frame(height: 500)
+        #endif
     }
 
     private var header: some View {
@@ -44,7 +53,7 @@ struct ProfileView: View {
                 ProfilePicture(user: user)
                     .frame(width: 100, height: 100)
 
-                VStack(alignment: .leading) {
+                VStack(alignment: .center) {
                     Text(user.name)
                         .font(.title)
                         .bold()

--- a/CanvasPlusPlayground/Features/Profile/ProfileView.swift
+++ b/CanvasPlusPlayground/Features/Profile/ProfileView.swift
@@ -108,24 +108,3 @@ struct ProfileView: View {
         }
     }
 }
-
-struct ProfilePicture: View {
-    let user: User
-
-    var body: some View {
-        AsyncImage(url: user.avatarURL) { image in
-            image
-                .resizable()
-                .clipShape(.circle)
-        } placeholder: {
-            Image(systemName: "person.circle.fill")
-                .resizable()
-                .foregroundColor(.gray)
-        }
-        .overlay {
-            Circle()
-                .stroke(lineWidth: 1)
-                .fill(.separator)
-        }
-    }
-}

--- a/CanvasPlusPlayground/Features/Profile/ProfileView.swift
+++ b/CanvasPlusPlayground/Features/Profile/ProfileView.swift
@@ -1,0 +1,110 @@
+//
+//  ProfileView.swift
+//  CanvasPlusPlayground
+//
+//  Created by Rahul on 2/4/25.
+//
+
+import SwiftUI
+
+struct ProfileView: View {
+    @Environment(ProfileManager.self) private var profileManager
+    @Environment(\.dismiss) private var dismiss
+
+    let user: User
+    @State private var profile: Profile? // needed to get email for curr user
+
+    var body: some View {
+        Form {
+            Section {
+                header
+                    .listRowBackground(Color.clear)
+            }
+
+            details
+        }
+        .formStyle(.grouped)
+        .task {
+            profile = await profileManager.getProfile(for: user.id)
+        }
+        .toolbar {
+            ToolbarItem(placement: .confirmationAction) {
+                Button("Done") {
+                    dismiss()
+                }
+            }
+        }
+        .animation(.default, value: profile)
+    }
+
+    private var header: some View {
+        HStack {
+            Spacer()
+            VStack {
+                ProfilePicture(user: user)
+                    .frame(width: 100, height: 100)
+
+                VStack(alignment: .leading) {
+                    Text(user.name)
+                        .font(.title)
+                        .bold()
+                        .padding(.top, 5)
+                        .multilineTextAlignment(.center)
+
+                    if let pronouns = user.pronouns {
+                        Text(pronouns)
+                            .font(.title3)
+                            .foregroundColor(.secondary)
+                            .italic()
+                    }
+                }
+            }
+            Spacer()
+        }
+    }
+
+    @ViewBuilder
+    private var details: some View {
+        if let bio = profile?.bio {
+            LabeledContent("Bio", value: bio)
+        }
+
+        if let pronunciation = profile?.pronunciation {
+            LabeledContent("Pronunciation", value: pronunciation)
+        }
+
+        if let email = profile?.primaryEmail {
+            LabeledContent("Primary Email", value: email)
+        }
+
+        LabeledContent("Short Name", value: user.shortName)
+
+        if !user.enrollmentRoles.isEmpty {
+            LabeledContent(
+                "Roles",
+                value: user.enrollmentRoles.map(\.displayName).joined(separator: ", ")
+            )
+        }
+    }
+}
+
+struct ProfilePicture: View {
+    let user: User
+
+    var body: some View {
+        AsyncImage(url: user.avatarURL) { image in
+            image
+                .resizable()
+                .clipShape(.circle)
+        } placeholder: {
+            Image(systemName: "person.circle.fill")
+                .resizable()
+                .foregroundColor(.gray)
+        }
+        .overlay {
+            Circle()
+                .stroke(lineWidth: 1)
+                .fill(.separator)
+        }
+    }
+}


### PR DESCRIPTION
Fixes #183 & #185

## Changes Made

- Make `Profile` cacheable by amending the `GetUserProfileRequest` with the required protocol
- Create a `ProfileView` that displays profile details, including name, email (only for current user), pronouns, bio (if available), avatar
- Incorporate `PeopleCommonView` into `ProfileView` as a Section
- Use the new ` navigationTransition` API on iOS/iPadOS on iOS 18.0+
- Ignores Canvas default profile pic and uses SF symbol if user doesn't have an avatar

## Screenshots (if applicable)

![SCR-20250205-jtls](https://github.com/user-attachments/assets/d6027841-4fef-4062-9e1e-dfaeeacf24e9)
<img width="1305" alt="Screenshot 2025-02-05 at 10 41 22 AM" src="https://github.com/user-attachments/assets/ce429b4c-3be2-4178-b03c-3a6de6cca7a2" />
<img width="1305" alt="Screenshot 2025-02-05 at 10 41 32 AM" src="https://github.com/user-attachments/assets/b9b16e3c-b9d5-410b-a0c9-e56977d1cb2b" />

https://github.com/user-attachments/assets/1fbc7caa-bafb-430c-9875-4b48da5695f8

## Checklist
- [x] I have implemented all requirements for this PR and its accompanying issue.
- [x] I have verified my implementation across all edge cases.
- [x] I executed `swiftlint --fix` on my code for cleanness.
