### PR TITLE
Refresh Button for People View (macOS)

### DIFF
--- a/CanvasPlusPlayground/Features/People/PeopleManager.swift
+++ b/CanvasPlusPlayground/Features/People/PeopleManager.swift
@@ -99,12 +99,14 @@ class PeopleManager: SearchResultListDataSource {
         }
 
     }
-    
-    func reloadPeople() {
-        guard let courseID = courseID else { return }
+    func resetState() {
         page = 1
         users = Set()
         loadingState = .loading
+        queryMode = .live
+    }
+    func reloadPeople() {
+        resetState()
         Task {
             try await fetchPeople()
         }

--- a/CanvasPlusPlayground/Features/People/PeopleManager.swift
+++ b/CanvasPlusPlayground/Features/People/PeopleManager.swift
@@ -99,6 +99,16 @@ class PeopleManager: SearchResultListDataSource {
         }
 
     }
+    
+    func reloadPeople() {
+        guard let courseID = courseID else { return }
+        page = 1
+        users = Set()
+        loadingState = .loading
+        Task {
+            try await fetchPeople()
+        }
+    }
 
     @MainActor
     private func addNewUsers(_ newUsers: [User]) {

--- a/CanvasPlusPlayground/Features/People/PeopleManager.swift
+++ b/CanvasPlusPlayground/Features/People/PeopleManager.swift
@@ -99,18 +99,6 @@ class PeopleManager: SearchResultListDataSource {
         }
 
     }
-    func resetState() {
-        page = 1
-        users = Set()
-        loadingState = .loading
-        queryMode = .live
-    }
-    func reloadPeople() {
-        resetState()
-        Task {
-            try await fetchPeople()
-        }
-    }
 
     @MainActor
     private func addNewUsers(_ newUsers: [User]) {

--- a/CanvasPlusPlayground/Features/People/PeopleView.swift
+++ b/CanvasPlusPlayground/Features/People/PeopleView.swift
@@ -74,12 +74,12 @@ struct PeopleView: View {
         ) { token in
             Label(token.category.displayName, systemImage: "person.fill")
         }
+        .toolbar {
+            Button("Reload", systemImage: "arrow.clockwise.circle", action: peopleManager.reloadPeople)
+        }
         #endif
         .overlay {
             noResultsBanner
-        }
-        .toolbar {
-            Button("Reload", systemImage: "arrow.clockwise.circle", action: peopleManager.reloadPeople)
         }
         .onChange(of: searchText) { _, _ in
             newQueryAsync()

--- a/CanvasPlusPlayground/Features/People/PeopleView.swift
+++ b/CanvasPlusPlayground/Features/People/PeopleView.swift
@@ -79,8 +79,8 @@ struct PeopleView: View {
                 currentSearchTask?.cancel()
                 peopleManager.users = Set()
                 peopleManager.loadingState = .loading
-                Task {
-                    await newQuery()
+                currentSearchTask = Task {
+                    newQueryAsync()
                 }
             }
         }

--- a/CanvasPlusPlayground/Features/People/PeopleView.swift
+++ b/CanvasPlusPlayground/Features/People/PeopleView.swift
@@ -78,6 +78,9 @@ struct PeopleView: View {
         .overlay {
             noResultsBanner
         }
+        .toolbar {
+            Button("Reload", systemImage: "arrow.clockwise.circle", action: peopleManager.reloadPeople)
+        }
         .onChange(of: searchText) { _, _ in
             newQueryAsync()
         }

--- a/CanvasPlusPlayground/Features/People/PeopleView.swift
+++ b/CanvasPlusPlayground/Features/People/PeopleView.swift
@@ -75,7 +75,14 @@ struct PeopleView: View {
             Label(token.category.displayName, systemImage: "person.fill")
         }
         .toolbar {
-            Button("Reload", systemImage: "arrow.clockwise.circle", action: peopleManager.reloadPeople)
+            Button("Reload", systemImage: "arrow.clockwise.circle") {
+                currentSearchTask?.cancel()
+                peopleManager.users = Set()
+                peopleManager.loadingState = .loading
+                Task {
+                    await newQuery()
+                }
+            }
         }
         #endif
         .overlay {

--- a/CanvasPlusPlayground/Features/People/PeopleView.swift
+++ b/CanvasPlusPlayground/Features/People/PeopleView.swift
@@ -74,11 +74,9 @@ struct PeopleView: View {
         ) { token in
             Label(token.category.displayName, systemImage: "person.fill")
         }
-        #if os(macOS)
         .toolbar {
             Button("Reload", systemImage: "arrow.clockwise.circle", action: peopleManager.reloadPeople)
         }
-        #endif
         #endif
         .overlay {
             noResultsBanner

--- a/CanvasPlusPlayground/Features/People/PeopleView.swift
+++ b/CanvasPlusPlayground/Features/People/PeopleView.swift
@@ -74,9 +74,11 @@ struct PeopleView: View {
         ) { token in
             Label(token.category.displayName, systemImage: "person.fill")
         }
+        #if os(macOS)
         .toolbar {
             Button("Reload", systemImage: "arrow.clockwise.circle", action: peopleManager.reloadPeople)
         }
+        #endif
         #endif
         .overlay {
             noResultsBanner


### PR DESCRIPTION
Fixes #189 

## Changes Made

- Added toolbar item to PeopleView
- Added reloadPeople() method in PeopleManager, which just calls fetchPeople() after reinitializing some state

## Screenshots (if applicable)

https://github.com/user-attachments/assets/a18f5734-e149-4af3-8719-a761d43e6f17


## Checklist
- [x] I have implemented all requirements for this PR and its accompanying issue.
- [x] I have verified my implementation across all edge cases.
- [x] I executed `swiftlint --fix` on my code for cleanness.
