### PR TITLE
setCourse run in main thread

### DIFF
--- a/CanvasPlusPlayground/Features/Courses/CourseManager.swift
+++ b/CanvasPlusPlayground/Features/Courses/CourseManager.swift
@@ -58,8 +58,6 @@ class CourseManager {
 
     @MainActor
     func setCourses(_ courses: [Course]) {
-        DispatchQueue.main.async {
-                self.allCourses = courses
-        }
+        self.allCourses = courses
     }
 }

--- a/CanvasPlusPlayground/Features/Courses/CourseManager.swift
+++ b/CanvasPlusPlayground/Features/Courses/CourseManager.swift
@@ -43,18 +43,23 @@ class CourseManager {
                 CanvasRequest.getCourses(enrollmentState: "active"),
                 onCacheReceive: { cachedCourses in
                     guard let cachedCourses else { return }
-                    setCourses(cachedCourses)
+                    Task { @MainActor in
+                        self.setCourses(cachedCourses)
+                    }
                 }
             )
             print(courses.map(\.name))
 
-            setCourses(courses)
+            await setCourses(courses)
         } catch {
             print("Failed to fetch courses. \(error)")
         }
     }
 
+    @MainActor
     func setCourses(_ courses: [Course]) {
-        self.allCourses = courses
+        DispatchQueue.main.async {
+                self.allCourses = courses
+        }
     }
 }


### PR DESCRIPTION
Fixes #196

## Changes Made

- Dispatch `setCourse` on Main thread instead of background thread
- Task in `getCourses` to ensure `setCourse` is called on the main thread
- `await setCourses(courses)` added to ensure `setCourses` completes

## Screenshots (if applicable)

## Checklist
- [x] I have implemented all requirements for this PR and its accompanying issue.
- [x] I have verified my implementation across all edge cases.
- [x] I executed `swiftlint --fix` on my code for cleanness.
