### PR TITLE
Fix files not working in offline mode

### DIFF
--- a/CanvasPlusPlayground/Common/Network/API Requests/GetFilesInFolderRequest.swift
+++ b/CanvasPlusPlayground/Common/Network/API Requests/GetFilesInFolderRequest.swift
@@ -77,7 +77,7 @@ struct GetFilesInFolderRequest: CacheableArrayAPIRequest {
         }
 
         let searchTerm = searchTerm ?? ""
-        let searchPred = #Predicate<File> { file in
+        let searchPred = searchTerm.isEmpty ? .true : #Predicate<File> { file in
             file.displayName.localizedStandardContains(searchTerm)
         }
 

--- a/CanvasPlusPlayground/Features/Files/CourseFileService.swift
+++ b/CanvasPlusPlayground/Features/Files/CourseFileService.swift
@@ -81,7 +81,8 @@ struct CourseFileService {
         let fileLoc = try? pathWithFolders(foldersPath: foldersPath, courseId: course.id, fileId: file.id, type: FileType.fromFile(file))
 
         // Provide local copy meanwhile
-        if let fileLoc, Self.fileManager.fileExists(atPath: fileLoc.path()), let data = try? Data(contentsOf: fileLoc) {
+        if let fileLoc, Self.fileManager.fileExists(atPath: fileLoc.path(percentEncoded: false)),
+            let data = try? Data(contentsOf: fileLoc) {
             localCopyReceived(data)
         }
 


### PR DESCRIPTION
Fixes #165

## Changes Made

- To load a saved file from disk correctly: Although we are saving the file properly to disk, when we query to check whether the file already exists on disk (so we present it immediately), the comparison check for the file path was incorrect. The path included special characters like "%20", which caused an incorrect result of the file "not existing". Using the `percentEncoded` argument, we can fix this.
- To load cached files correctly: we were missing a check in `customPredicate` to see whether the `searchTerm` was empty before doing the comparison

## Screenshots (if applicable)

## Checklist
- [x] I have implemented all requirements for this PR and its accompanying issue.
- [x] I have verified my implementation across all edge cases.
- [x] I executed `swiftlint --fix` on my code for cleanness.
