### PR TITLE
Use QuickLook to preview files

### DIFF
--- a/CanvasPlusPlayground.xcodeproj/project.pbxproj
+++ b/CanvasPlusPlayground.xcodeproj/project.pbxproj
@@ -99,6 +99,7 @@
 		B53D95A02CA0953900647EE9 /* PeopleManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53D959F2CA0952F00647EE9 /* PeopleManager.swift */; };
 		B53D95A22CA0A22A00647EE9 /* PeopleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53D95A12CA0A22A00647EE9 /* PeopleView.swift */; };
 		B73AE0BD2D4FB68B007094A8 /* Profile.swift in Sources */ = {isa = PBXBuildFile; fileRef = B73AE0BC2D4FB68B007094A8 /* Profile.swift */; };
+		B72EA5702D5689B20013070E /* QuickLookPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = B72EA56F2D5689B20013070E /* QuickLookPreview.swift */; };
 		B76454FE2C8DF61B002DF00E /* Course.swift in Sources */ = {isa = PBXBuildFile; fileRef = B76454ED2C8DF61B002DF00E /* Course.swift */; };
 		B76454FF2C8DF61B002DF00E /* Enrollment.swift in Sources */ = {isa = PBXBuildFile; fileRef = B76454EE2C8DF61B002DF00E /* Enrollment.swift */; };
 		B76455002C8DF61B002DF00E /* File.swift in Sources */ = {isa = PBXBuildFile; fileRef = B76454EF2C8DF61B002DF00E /* File.swift */; };
@@ -242,6 +243,7 @@
 		B53D959F2CA0952F00647EE9 /* PeopleManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeopleManager.swift; sourceTree = "<group>"; };
 		B53D95A12CA0A22A00647EE9 /* PeopleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeopleView.swift; sourceTree = "<group>"; };
 		B73AE0BC2D4FB68B007094A8 /* Profile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Profile.swift; sourceTree = "<group>"; };
+		B72EA56F2D5689B20013070E /* QuickLookPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickLookPreview.swift; sourceTree = "<group>"; };
 		B76454642C8BBC7F002DF00E /* CanvasPlusPlayground.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CanvasPlusPlayground.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B76454ED2C8DF61B002DF00E /* Course.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Course.swift; sourceTree = "<group>"; };
 		B76454EE2C8DF61B002DF00E /* Enrollment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Enrollment.swift; sourceTree = "<group>"; };
@@ -397,6 +399,7 @@
 				A324BA632D07AF0B005F53FA /* CourseFileService.swift */,
 				A324BA652D07AFD5005F53FA /* FileType.swift */,
 				A324BA672D07C2E9005F53FA /* FileViewer.swift */,
+				B72EA56F2D5689B20013070E /* QuickLookPreview.swift */,
 			);
 			path = Files;
 			sourceTree = "<group>";
@@ -921,6 +924,7 @@
 				A31A81E72D0CCB69003C37EB /* GradesViewModel.swift in Sources */,
 				A373DC142D19FA2A00215019 /* APICourseSection.swift in Sources */,
 				A3E7F38B2C9555B200DC4300 /* CanvasService.swift in Sources */,
+				B72EA5702D5689B20013070E /* QuickLookPreview.swift in Sources */,
 				B76455082C8DF61B002DF00E /* CourseManager.swift in Sources */,
 				A3CF88E12D1921C3000ACDF3 /* AnnouncementAPI.swift in Sources */,
 				A3D1614F2D1784E3004055FB /* GetUserRequest.swift in Sources */,

--- a/CanvasPlusPlayground/Features/Files/CourseFileService.swift
+++ b/CanvasPlusPlayground/Features/Files/CourseFileService.swift
@@ -75,7 +75,8 @@ struct CourseFileService {
         return fileURL
     }
 
-    func locationForCourseFile(
+    @discardableResult
+    func setLocationForCourseFile(
         _ file: File,
         course: Course,
         foldersPath: [String]
@@ -110,7 +111,7 @@ struct CourseFileService {
         localCopyReceived: (Data?, URL) -> Void
     ) async throws -> (Data, URL) {
         // Provide local copy meanwhile
-        if let fileLoc = self.locationForCourseFile(file, course: course, foldersPath: foldersPath),
+        if let fileLoc = self.setLocationForCourseFile(file, course: course, foldersPath: foldersPath),
            let data = try? Data(contentsOf: fileLoc) {
             localCopyReceived(data, fileLoc)
         }

--- a/CanvasPlusPlayground/Features/Files/CourseFileService.swift
+++ b/CanvasPlusPlayground/Features/Files/CourseFileService.swift
@@ -65,6 +65,8 @@ struct CourseFileService {
 
         do {
             try content.write(to: fileURL, options: .atomic)
+
+            file.localURL = fileURL
         } catch {
             print("Writing failed due to \(error)")
             throw FileError.fileWriteFailed
@@ -84,7 +86,16 @@ struct CourseFileService {
         if let fileLoc, Self.fileManager
             .fileExists(atPath: fileLoc.path(percentEncoded: false)) {
             print("File exists locally!\n")
+
+            if fileLoc != file.localURL {
+                print("Updating File's localURL")
+                file.localURL = fileLoc
+            }
+
             return fileLoc
+        } else if file.localURL != nil {
+            print("Updating File's localURL to nil since it no longer exists locally")
+            file.localURL = nil
         }
 
         print("File does not exist locally\n")

--- a/CanvasPlusPlayground/Features/Files/FileType.swift
+++ b/CanvasPlusPlayground/Features/Files/FileType.swift
@@ -6,31 +6,23 @@
 //
 
 import Foundation
+import QuickLook
 
-enum FileType {
-    case latex, docx, pdf
+struct FileType {
+    let fileExtension: String
 
     var formatExtension: String {
-        switch self {
-        case .latex: return ".latex"
-        case .docx: return ".docx"
-        case .pdf: return ".pdf"
-        }
+        "." + fileExtension
+    }
+
+    init(file: File) {
+        self.fileExtension = Self.extensionFromFile(file)
     }
 
     /// Checks the filename for file format, returns nil if File format isn't supported or format was uninferable.
-    static func fromFile(_ file: File) -> FileType? {
+    static func extensionFromFile(_ file: File) -> String {
         let fileExtension = URL(fileURLWithPath: file.filename).pathExtension.lowercased()
 
-        switch fileExtension {
-        case "latex": return .latex
-        case "docx": return .docx
-        case "pdf": return .pdf
-        default: return nil
-        }
-    }
-
-    static func isSupported(_ file: File) -> Bool {
-        self.fromFile(file) != nil
+        return fileExtension
     }
 }

--- a/CanvasPlusPlayground/Features/Files/FileType.swift
+++ b/CanvasPlusPlayground/Features/Files/FileType.swift
@@ -19,8 +19,7 @@ struct FileType {
         self.fileExtension = Self.extensionFromFile(file)
     }
 
-    /// Checks the filename for file format, returns nil if File format isn't supported or format was uninferable.
-    static func extensionFromFile(_ file: File) -> String {
+    private static func extensionFromFile(_ file: File) -> String {
         let fileExtension = URL(fileURLWithPath: file.filename).pathExtension.lowercased()
 
         return fileExtension

--- a/CanvasPlusPlayground/Features/Files/FileViewer.swift
+++ b/CanvasPlusPlayground/Features/Files/FileViewer.swift
@@ -15,7 +15,6 @@ struct FileViewer: View {
     let fileService = CourseFileService()
 
     @Environment(CourseFileViewModel.self) var courseFileVM
-    @State private var content: Data?
     @State private var url: URL?
     @State private var isLoading = false
 
@@ -59,7 +58,7 @@ struct FileViewer: View {
     private func loadContents() async {
         isLoading = true
         do {
-            (self.content, self.url) = try await fileService.courseFile(
+            (_, self.url) = try await fileService.courseFile(
                 for: file,
                 course: course,
                 foldersPath: courseFileVM.traversedFolderIDs,

--- a/CanvasPlusPlayground/Features/Files/FileViewer.swift
+++ b/CanvasPlusPlayground/Features/Files/FileViewer.swift
@@ -8,44 +8,66 @@
 import SwiftUI
 
 struct FileViewer: View {
+    @Environment(\.dismiss) private var dismiss
+
     let course: Course
     let file: File
     let fileService = CourseFileService()
 
     @Environment(CourseFileViewModel.self) var courseFileVM
-    @State var content: Data?
-
-    var fileType: FileType? {
-        FileType.fromFile(file)
-    }
+    @State private var content: Data?
+    @State private var url: URL?
+    @State private var isLoading = false
 
     var body: some View {
-        VStack {
-            if let content, let fileType {
-                switch fileType {
-                case .latex:
-                    EmptyView()
-                case .docx:
-                    EmptyView()
-                case .pdf:
-                    CoursePDFView(source: .data(content))
-                }
-            } else if content != nil {
-                ContentUnavailableView("Preview not supported for this file.", systemImage: "xmark.rectangle.fill")
+        Group {
+            if let url {
+                QuickLookPreview(url: url) { dismiss() }
+                    #if os(iOS)
+                    .navigationBarBackButtonHidden()
+                    .ignoresSafeArea()
+                    #else
+                    .toolbar {
+                        ShareLink(item: url)
+                    }
+                    #endif
             } else {
-                ContentUnavailableView("Unable to download file.", systemImage: "xmark.rectangle.fill")
-            }
-        }.task {
-            do {
-                self.content = try await fileService.courseFile(
-                    for: file,
-                    course: course,
-                    foldersPath: courseFileVM.traversedFolderIDs,
-                    localCopyReceived: { self.content = $0 }
-                )
-            } catch {
-                print("Error fetching file content: \(error)")
+                Group {
+                    if isLoading {
+                        VStack(spacing: 12) {
+                            ProgressView()
+                            Text("Loading...")
+                        }
+                    } else {
+                        ContentUnavailableView("Unable to preview file.", systemImage: "xmark.rectangle.fill")
+                    }
+                }
+                #if os(iOS)
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button("Done") { dismiss() }
+                    }
+                }
+                #endif
             }
         }
+        .task {
+            await loadContents()
+        }
+    }
+
+    private func loadContents() async {
+        isLoading = true
+        do {
+            (self.content, self.url) = try await fileService.courseFile(
+                for: file,
+                course: course,
+                foldersPath: courseFileVM.traversedFolderIDs,
+                localCopyReceived: { (_, self.url) = ($0, $1) }
+            )
+        } catch {
+            print("Error fetching file content: \(error)")
+        }
+        self.isLoading = false
     }
 }

--- a/CanvasPlusPlayground/Features/Files/FoldersPageView.swift
+++ b/CanvasPlusPlayground/Features/Files/FoldersPageView.swift
@@ -13,6 +13,7 @@ struct FoldersPageView: View {
     @State private var filesVM: CourseFileViewModel
 
     @State private var isLoadingContents = true
+    @State private var selectedFile: File?
 
     init(course: Course, folder: Folder? = nil, traversedFolderIDs: [String] = []) {
         self.course = course
@@ -22,66 +23,68 @@ struct FoldersPageView: View {
     }
 
     var body: some View {
-        List {
-            Section("Files") {
-                ForEach(filesVM.displayedFiles, id: \.id) { file in
-                    fileRow(for: file)
-                        .listItemTint(course.rgbColors?.color)
+        List(selection: $selectedFile) {
+            if !filesVM.displayedFiles.isEmpty {
+                Section("Files") {
+                    ForEach(filesVM.displayedFiles, id: \.id) { file in
+                        fileRow(for: file)
+                            .tag(file)
+                            .listItemTint(course.rgbColors?.color)
+                    }
                 }
             }
 
-            Section("Folders") {
-                ForEach(filesVM.displayedFolders, id: \.id) { subFolder in
-                    folderRow(for: subFolder)
-                        .listItemTint(course.rgbColors?.color)
+            if !filesVM.displayedFolders.isEmpty {
+                Section("Folders") {
+                    ForEach(filesVM.displayedFolders, id: \.id) { subFolder in
+                        folderRow(for: subFolder)
+                            .listItemTint(course.rgbColors?.color)
+                    }
                 }
             }
-
         }
         .task {
             await loadContents()
+        }
+        #if os(iOS)
+        .fullScreenCover(item: $selectedFile) { file in
+            NavigationStack {
+                FileViewer(course: course, file: file)
+            }
+                .environment(filesVM)
+        }
+        #else
+        .navigationDestination(item: $selectedFile) { file in
+            FileViewer(course: course, file: file)
+                .environment(filesVM)
+        }
+        #endif
+        .overlay {
+            if !isLoadingContents && filesVM.displayedFiles.isEmpty && filesVM.displayedFolders.isEmpty {
+                ContentUnavailableView("This folder is empty.", systemImage: "folder")
+            }
         }
         .statusToolbarItem(
             folder?.name ?? "Files",
             isVisible: isLoadingContents
         )
-        .navigationTitle("Files")
+        .navigationTitle(folder?.name?.capitalized ?? "Files")
     }
 
     @ViewBuilder
     func fileRow(for file: File) -> some View {
         if file.url != nil {
-            NavigationLink(destination: destination(for: file)) {
-                Label(file.displayName, systemImage: "document")
-            }
-            .contextMenu {
-                PinButton(
-                    itemID: file.id,
-                    courseID: course.id,
-                    type: .file
-                )
-            }
-            .swipeActions(edge: .leading) {
-                PinButton(
-                    itemID: file.id,
-                    courseID: course.id,
-                    type: .file
-                )
-            }
+            FileRow(file: file, course: course)
+                .environment(filesVM)
         } else {
             Label("File not available.", systemImage: "document")
         }
     }
 
-    func destination(for file: File) -> some View {
-        FileViewer(course: course, file: file)
-            .environment(filesVM)
-    }
-
     @ViewBuilder
     func folderRow(for subFolder: Folder) -> some View {
         NavigationLink(destination: FoldersPageView(course: course, folder: subFolder, traversedFolderIDs: filesVM.traversedFolderIDs)) {
-            Label(subFolder.name ?? "Couldn't find folder name.", systemImage: "folder")
+            FolderRow(folder: subFolder)
         }
     }
 
@@ -93,5 +96,88 @@ struct FoldersPageView: View {
             self.folder = await filesVM.fetchRoot()
         }
         isLoadingContents = false
+    }
+}
+
+private struct FileRow: View {
+    @Environment(CourseFileViewModel.self) private var filesVM
+    let file: File
+    let course: Course
+
+    @State private var localFileExists = false
+
+    var body: some View {
+        HStack {
+            mainContent
+
+            Spacer()
+
+            if !localFileExists {
+                Image(systemName: "arrow.down.circle.dotted")
+            }
+        }
+        .imageScale(.large)
+        .contextMenu {
+            PinButton(
+                itemID: file.id,
+                courseID: course.id,
+                type: .file
+            )
+        }
+        .swipeActions(edge: .leading) {
+            PinButton(
+                itemID: file.id,
+                courseID: course.id,
+                type: .file
+            )
+        }
+        .onAppear {
+            localFileExists = CourseFileService.shared.locationForCourseFile(
+                file,
+                course: course,
+                foldersPath: filesVM.traversedFolderIDs
+            ) != nil
+        }
+    }
+
+    private var mainContent: some View {
+        HStack {
+            Image(systemName: "document")
+                .foregroundStyle(.tint)
+
+            VStack(alignment: .leading) {
+                Text(file.displayName)
+                    .font(.headline)
+
+                if let size = file.size {
+                    Text(size.formatted(.byteCount(style: .file)))
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+}
+
+private struct FolderRow: View {
+    let folder: Folder
+
+    var body: some View {
+        HStack {
+            Image(systemName: "folder")
+                .foregroundStyle(.tint)
+
+            VStack(alignment: .leading) {
+                Text(folder.name ?? "Unknown Folder")
+                    .font(.headline)
+
+                Text("\(count) items")
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .imageScale(.large)
+    }
+
+    var count: Int {
+        (folder.filesCount ?? 0) + (folder.foldersCount ?? 0)
     }
 }

--- a/CanvasPlusPlayground/Features/Files/FoldersPageView.swift
+++ b/CanvasPlusPlayground/Features/Files/FoldersPageView.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct FoldersPageView: View {
+    @Namespace private var namespace
+
     let course: Course
     @State var folder: Folder?
     @State private var filesVM: CourseFileViewModel
@@ -48,10 +50,19 @@ struct FoldersPageView: View {
         }
         #if os(iOS)
         .fullScreenCover(item: $selectedFile) { file in
-            NavigationStack {
-                FileViewer(course: course, file: file)
+            Group {
+                if #available(iOS 18.0, *) {
+                    NavigationStack {
+                        FileViewer(course: course, file: file)
+                    }
+                    .navigationTransition(.zoom(sourceID: file.id, in: namespace))
+                } else {
+                    NavigationStack {
+                        FileViewer(course: course, file: file)
+                    }
+                }
             }
-                .environment(filesVM)
+            .environment(filesVM)
         }
         #else
         .navigationDestination(item: $selectedFile) { file in
@@ -74,8 +85,17 @@ struct FoldersPageView: View {
     @ViewBuilder
     func fileRow(for file: File) -> some View {
         if file.url != nil {
-            FileRow(file: file, course: course)
-                .environment(filesVM)
+            Group {
+                if #available(iOS 18.0, *) {
+                    FileRow(file: file, course: course)
+                        #if os(iOS)
+                        .matchedTransitionSource(id: file.id, in: namespace)
+                        #endif
+                } else {
+                    FileRow(file: file, course: course)
+                }
+            }
+            .environment(filesVM)
         } else {
             Label("File not available.", systemImage: "document")
         }

--- a/CanvasPlusPlayground/Features/Files/FoldersPageView.swift
+++ b/CanvasPlusPlayground/Features/Files/FoldersPageView.swift
@@ -151,8 +151,8 @@ private struct FileRow: View {
         }
         .onAppear {
             // Updates file.localURL if needed
-            _ = CourseFileService.shared
-                .locationForCourseFile(
+            CourseFileService.shared
+                .setLocationForCourseFile(
                     file,
                     course: course,
                     foldersPath: filesVM.traversedFolderIDs

--- a/CanvasPlusPlayground/Features/Files/FoldersPageView.swift
+++ b/CanvasPlusPlayground/Features/Files/FoldersPageView.swift
@@ -104,15 +104,13 @@ private struct FileRow: View {
     let file: File
     let course: Course
 
-    @State private var localFileExists = false
-
     var body: some View {
         HStack {
             mainContent
 
             Spacer()
 
-            if !localFileExists {
+            if file.localURL == nil {
                 Image(systemName: "arrow.down.circle.dotted")
             }
         }
@@ -132,11 +130,13 @@ private struct FileRow: View {
             )
         }
         .onAppear {
-            localFileExists = CourseFileService.shared.locationForCourseFile(
-                file,
-                course: course,
-                foldersPath: filesVM.traversedFolderIDs
-            ) != nil
+            // Updates file.localURL if needed
+            _ = CourseFileService.shared
+                .locationForCourseFile(
+                    file,
+                    course: course,
+                    foldersPath: filesVM.traversedFolderIDs
+                )
         }
     }
 

--- a/CanvasPlusPlayground/Features/Files/Models/File.swift
+++ b/CanvasPlusPlayground/Features/Files/Models/File.swift
@@ -74,6 +74,9 @@ class File: Cacheable {
     var lockedForUser: Bool?
     var visibilityLevel: String?
 
+    // MARK: Custom Properties
+    var localURL: URL?
+
     init(api: FileAPI) {
         self.id = api.id.asString
 

--- a/CanvasPlusPlayground/Features/Files/QuickLookPreview.swift
+++ b/CanvasPlusPlayground/Features/Files/QuickLookPreview.swift
@@ -1,0 +1,105 @@
+//
+//  QuickLookPreview.swift
+//  CanvasPlusPlayground
+//
+//  Created by Rahul on 2/7/25.
+//
+
+import SwiftUI
+
+#if os(iOS)
+import QuickLook
+#elseif os(macOS)
+import QuickLookUI
+#endif
+
+#if os(iOS)
+typealias PlatformViewControllerRepresentable = UIViewControllerRepresentable
+#elseif os(macOS)
+typealias PlatformViewControllerRepresentable = NSViewRepresentable
+#endif
+
+struct QuickLookPreview: PlatformViewControllerRepresentable {
+    let url: URL
+    let onDismiss: () -> Void
+
+    #if os(iOS)
+    func makeUIViewController(context: Context) -> UINavigationController {
+        let controller = QLPreviewController()
+        controller.dataSource = context.coordinator
+        controller.navigationItem.leftBarButtonItem = UIBarButtonItem(
+            barButtonSystemItem: .done, target: context.coordinator,
+            action: #selector(context.coordinator.dismiss)
+        )
+
+        let navigationController = UINavigationController(
+            rootViewController: controller
+        )
+        return navigationController
+    }
+
+    func updateUIViewController(
+        _ uiViewController: UINavigationController,
+        context: Context
+    ) {
+    }
+    #elseif os(macOS)
+    func makeNSView(context: Context) -> QLPreviewView {
+        let controller = QLPreviewView()
+        controller.autostarts = true
+        controller.previewItem = url as QLPreviewItem
+
+        return controller
+    }
+
+    func updateNSView(_ nsView: QLPreviewView, context: Context) { }
+    #endif
+
+    func makeCoordinator() -> Coordinator {
+        return Coordinator(parent: self)
+    }
+
+    #if os(iOS)
+    class Coordinator: NSObject, QLPreviewControllerDataSource {
+        let parent: QuickLookPreview
+
+        init(parent: QuickLookPreview) {
+            self.parent = parent
+            super.init()
+        }
+
+        func numberOfPreviewItems(in controller: QLPreviewController) -> Int {
+            return 1
+        }
+
+        func previewController(_ controller: QLPreviewController, previewItemAt index: Int) -> QLPreviewItem {
+            return parent.url as QLPreviewItem
+        }
+
+        @objc func dismiss() {
+            parent.onDismiss()
+        }
+    }
+    #elseif os(macOS)
+    class Coordinator: NSObject, QLPreviewPanelDataSource, QLPreviewPanelDelegate {
+        let parent: QuickLookPreview
+
+        init(parent: QuickLookPreview) {
+            self.parent = parent
+            super.init()
+        }
+
+        func numberOfPreviewItems(in panel: QLPreviewPanel!) -> Int {
+            return 1
+        }
+
+        func previewPanel(_ panel: QLPreviewPanel!, previewItemAt index: Int) -> QLPreviewItem! {
+            return parent.url as QLPreviewItem
+        }
+
+        func previewPanelDidClose(_ panel: QLPreviewPanel!) {
+            parent.onDismiss()
+        }
+    }
+    #endif
+}


### PR DESCRIPTION
Fixes #143 and #211.

## Changes Made

- Uses `QuickLook` API to preview different file types
- Adds a custom property to `File` to store localURL, if present
- Download icon next to each row if not locally present
- Use sheet on iOS
- Markup, other QuickLook utilities for free on iOS, `ShareLink` on macOS

## Screenshots (if applicable)

<img width="600" alt="Screenshot 2025-02-13 at 3 19 27 PM" src="https://github.com/user-attachments/assets/c1c28103-508e-465a-abfe-4de67dcc8a25" />
<img width="600" alt="Screenshot 2025-02-13 at 3 19 25 PM" src="https://github.com/user-attachments/assets/4c9ca7f8-3363-47b6-b26d-db8c46809534" />
<img width="300" alt="Screenshot 2025-02-13 at 3 19 27 PM" src="https://github.com/user-attachments/assets/d0de198b-4547-4e04-8401-7ab23e5e8dde" />

An item that "cannot be previewed" looks like this:
<img width="600" alt="Screenshot 2025-02-13 at 5 40 40 PM" src="https://github.com/user-attachments/assets/c0526df3-4b63-4e2c-8a55-05069464f280" />


## Checklist
- [x] I have implemented all requirements for this PR and its accompanying issue.
- [x] I have verified my implementation across all edge cases.
- [x] I have ensured my changes compile on macOS & iOS.
- [x] I executed `swiftlint --fix` on my code for cleanness.
