### PR TITLE
Use font sizing for profile picture icon

### DIFF
--- a/CanvasPlusPlayground/Features/Navigation/Sidebar.swift
+++ b/CanvasPlusPlayground/Features/Navigation/Sidebar.swift
@@ -75,11 +75,10 @@ struct Sidebar: View {
                     Button {
                         navigationModel.showProfileSheet.toggle()
                     } label: {
-                        ProfilePicture(user: currentUser)
                         #if os(macOS)
-                            .frame(width: 19, height: 19)
+                        ProfilePicture(user: currentUser, size: 19)
                         #else
-                            .frame(width: 24, height: 24)
+                        ProfilePicture(user: currentUser, size: 24)
                         #endif
                     }
                 }

--- a/CanvasPlusPlayground/Features/People/PeopleView.swift
+++ b/CanvasPlusPlayground/Features/People/PeopleView.swift
@@ -156,17 +156,16 @@ private struct UserCell: View {
         HStack {
             Group {
                 if #available(iOS 18.0, *) {
-                    ProfilePicture(user: user)
-                        .frame(width: 35, height: 35)
+                    ProfilePicture(user: user, size: 35)
                         #if os(iOS)
                         .matchedTransitionSource(id: user.id, in: namespace)
                         #endif
                 } else {
-                    ProfilePicture(user: user)
-                        .frame(width: 35, height: 35)
+                    ProfilePicture(user: user, size: 35)
                 }
             }
             .symbolVariant(.fill)
+            .foregroundStyle(.secondary)
 
             VStack(alignment: .leading) {
                 Text(user.name)

--- a/CanvasPlusPlayground/Features/Profile/ProfilePicture.swift
+++ b/CanvasPlusPlayground/Features/Profile/ProfilePicture.swift
@@ -15,6 +15,7 @@ private typealias PlatformImage = UIImage
 
 struct ProfilePicture: View {
     let user: User
+    var size: CGFloat
 
     var body: some View {
         Group {
@@ -32,14 +33,16 @@ struct ProfilePicture: View {
                 #endif
             } else {
                 Image(systemName: "person.circle")
-                    .resizable()
-                    .foregroundStyle(.tint)
+                    .font(.system(size: size))
             }
         }
+        .frame(width: size, height: size)
         .overlay {
-            Circle()
-                .stroke(lineWidth: 1)
-                .fill(.separator)
+            if user.hasAvatar {
+                Circle()
+                    .stroke(lineWidth: 1)
+                    .fill(.separator)
+            }
         }
         .task {
             guard user.hasAvatar, let url = user.avatarURL else { return }

--- a/CanvasPlusPlayground/Features/Profile/ProfileView.swift
+++ b/CanvasPlusPlayground/Features/Profile/ProfileView.swift
@@ -61,8 +61,7 @@ struct ProfileView: View {
         HStack {
             Spacer()
             VStack {
-                ProfilePicture(user: user)
-                    .frame(width: 100, height: 100)
+                ProfilePicture(user: user, size: 100)
                     .symbolVariant(.fill)
 
                 VStack(alignment: .center) {


### PR DESCRIPTION
## Changes Made

- Adds a new `size` parameter to `ProfilePicture` so that we can specify the SF Symbol size through a font and not through the `.resizable()` modifier
- This is important to ensure that we don't have a loss in resolution when doing that

## Screenshots (if applicable)

## Checklist
- [x] I have implemented all requirements for this PR and its accompanying issue.
- [x] I have verified my implementation across all edge cases.
- [x] I have ensured my changes compile on macOS & iOS.
- [x] I executed `swiftlint --fix` on my code for cleanness.
