### PR TITLE
Add rich tinting

### DIFF
--- a/CanvasPlusPlayground/Features/Assignments/CourseAssignmentView.swift
+++ b/CanvasPlusPlayground/Features/Assignments/CourseAssignmentView.swift
@@ -50,7 +50,7 @@ struct CourseAssignmentsView: View {
             await loadAssignments()
         }
         .statusToolbarItem("Assignments", isVisible: isLoadingAssignments)
-        .navigationTitle(course.displayName)
+        .navigationTitle("Assignments")
         .navigationDestination(for: AssignmentAPI.self) { assignment in
             AssignmentDetailView(assignment: assignment)
         }

--- a/CanvasPlusPlayground/Features/Courses/CourseView.swift
+++ b/CanvasPlusPlayground/Features/Courses/CourseView.swift
@@ -24,13 +24,15 @@ struct CourseView: View {
         .scrollContentBackground(course.rgbColors?.color == nil ? .automatic : .hidden)
         .background(alignment: .top) {
             if let color = course.rgbColors?.color {
-                LinearGradient(colors: [color, color.opacity(0)], startPoint: .top, endPoint: .bottom)
+                color
                     .overlay {
-                        LinearGradient(colors: [.white, .white.opacity(0)], startPoint: .center, endPoint: .bottom)
+                        LinearGradient(colors: [color, color.opacity(0)], startPoint: .top, endPoint: .bottom)
+                            .hueRotation(.degrees(35))
                             .blendMode(.overlay)
-                            .opacity(0)
                     }
-                    .opacity(0.5)
+                    .mask {
+                        LinearGradient(colors: [.black.opacity(0.5), .black.opacity(0)], startPoint: .top, endPoint: .bottom)
+                    }
                     .frame(height: 200)
                     .ignoresSafeArea()
             }

--- a/CanvasPlusPlayground/Features/Courses/CourseView.swift
+++ b/CanvasPlusPlayground/Features/Courses/CourseView.swift
@@ -21,6 +21,20 @@ struct CourseView: View {
         }
         .tint(course.rgbColors?.color)
         .navigationTitle(course.displayName)
+        .scrollContentBackground(course.rgbColors?.color == nil ? .automatic : .hidden)
+        .background(alignment: .top) {
+            if let color = course.rgbColors?.color {
+                LinearGradient(colors: [color, color.opacity(0)], startPoint: .top, endPoint: .bottom)
+                    .overlay {
+                        LinearGradient(colors: [.white, .white.opacity(0)], startPoint: .center, endPoint: .bottom)
+                            .blendMode(.overlay)
+                            .opacity(0)
+                    }
+                    .opacity(0.5)
+                    .frame(height: 200)
+                    .ignoresSafeArea()
+            }
+        }
         #if os(iOS)
         .listStyle(.insetGrouped)
         #else

--- a/CanvasPlusPlayground/Features/Navigation/HomeView.swift
+++ b/CanvasPlusPlayground/Features/Navigation/HomeView.swift
@@ -54,6 +54,7 @@ struct HomeView: View {
                 )
             }
         }
+        .tint(selectedCourse?.rgbColors?.color ?? .accentColor)
         .task {
             navigationModel.selectedNavigationPage = selectedNavigationPage
             navigationModel.selectedCoursePage = selectedCoursePage


### PR DESCRIPTION
## Changes Made

This pull request improves tinting within the Course view. More specifically, it enables tinting within the toolbar and adds a vivid gradient behind the main title header. It's similar to what we discussed with the design team. I think it might look a little funky on Mac and we could fix that.

Note: in macOS, you may notice that the profile icon is also tinted when a course is selected. That has been fixed within #222.

## Screenshots (if applicable)
<img width="374" alt="Screenshot 2025-02-13 at 2 58 54 PM" src="https://github.com/user-attachments/assets/11a7682d-8d9d-4d1c-93b1-b26902f592c6" />
<img width="374" alt="Screenshot 2025-02-13 at 2 58 51 PM" src="https://github.com/user-attachments/assets/a8e108e4-04bf-4342-b1c0-0eeb716905a8" />
<img width="374" alt="Screenshot 2025-02-13 at 2 58 45 PM" src="https://github.com/user-attachments/assets/1db14cb8-7f70-4025-adad-13f24168b4fe" />
<img width="374" alt="Screenshot 2025-02-13 at 2 58 38 PM" src="https://github.com/user-attachments/assets/8d6ee759-dc02-4d8a-8b37-8463d3115bde" />

<img width="374" alt="Screenshot 2025-02-13 at 3 01 50 PM" src="https://github.com/user-attachments/assets/e8611c7b-0a47-4875-bc4d-800c8a4e2c0e" />
<img width="374" alt="Screenshot 2025-02-13 at 3 01 33 PM" src="https://github.com/user-attachments/assets/f5f1677d-20bc-4c5c-b5e8-98053156827f" />
<img width="374" alt="Screenshot 2025-02-13 at 3 01 31 PM" src="https://github.com/user-attachments/assets/380277c5-d330-4110-8356-e2428fe8680c" />
<img width="374" alt="Screenshot 2025-02-13 at 3 01 29 PM" src="https://github.com/user-attachments/assets/dca871d9-1be6-4160-a53a-6791edfa3015" />

## Checklist
- [x] I have implemented all requirements for this PR and its accompanying issue.
- [x] I have verified my implementation across all edge cases.
- [x] I have ensured my changes compile on macOS & iOS.
- [x] I executed `swiftlint --fix` on my code for cleanness.
