### PR TITLE
SwiftLint Run Script

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,4 +12,4 @@ Fixes #<issue number, e.g. #100>
 - [ ] I have implemented all requirements for this PR and its accompanying issue.
 - [ ] I have verified my implementation across all edge cases.
 - [ ] I have ensured my changes compile on macOS & iOS.
-- [ ] I executed `swiftlint --fix` on my code for cleanness.
+- [ ] I have resolved all SwiftLint warnings.

--- a/CanvasPlusPlayground.xcodeproj/project.pbxproj
+++ b/CanvasPlusPlayground.xcodeproj/project.pbxproj
@@ -732,6 +732,7 @@
 				B76454602C8BBC7F002DF00E /* Sources */,
 				B76454612C8BBC7F002DF00E /* Frameworks */,
 				B76454622C8BBC7F002DF00E /* Resources */,
+				9ACDA5E82D5F1DA2001F1F0A /* SwiftLint */,
 			);
 			buildRules = (
 			);
@@ -795,6 +796,28 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		9ACDA5E82D5F1DA2001F1F0A /* SwiftLint */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = SwiftLint;
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [[ \"$(uname -m)\" == arm64 ]]; then\n    export PATH=\"/opt/homebrew/bin:$PATH\"\nfi\n\nif which swiftlint > /dev/null; then\n    swiftlint lint --fix\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		B76454602C8BBC7F002DF00E /* Sources */ = {

--- a/README.md
+++ b/README.md
@@ -18,18 +18,18 @@ This [feature database](https://gt-ios-club.notion.site/d2d21e2e80f3417d8528553f
 print(URL.applicationSupportDirectory.path(percentEncoded: false))
 ```
 
-### Swiftlint
+### SwiftLint
 
-This project uses [`swiftlint`](https://github.com/realm/SwiftLint), a Swift Package that ensures consistent code formatting across the codebase. Upon building the project, you will automatically see any swiftlint errors in Xcode. Please resolve these before merging new code into the codebase.
+This project uses [SwiftLint](https://github.com/realm/SwiftLint), a Swift Package that ensures consistent code formatting across the codebase. Please resolve these before merging new code into the codebase.
 
-'swiftlint` can automatically fix these most of these errors for you:
+SwiftLint can automatically fix these most of these errors for you:
 
-1. Install swiftlint via your Terminal: `brew install swiftlint`.
-2. Run `swiftlint --fix` within your project directory.
+1. Install `swiftlint` via your Terminal: `brew install swiftlint`.
+2. `swiflint lint --fix` automatically runs whenever you build or run in Xcode, which will fix most issues or throw warnings related to code formatting.
 
 To make your life easier, you can have Xcode automatically reformat after a particular column length, and trim trailing whitespaces:
 
-1. Open Xcode preferences (Cmd+",")
+1. Open Xcode preferences (<kbd>⌘</kbd> + <kbd>,</kbd>)
 2. Go to Text Editing > Editing
 3. Turn on "Automatically reformat when completing code", "Automatically trim trailing whitespaces", and "Including whitespace-only lines"
 


### PR DESCRIPTION
Fixes #216

## Changes Made

- Added SwiftLint to run scripts
- Currently, it is passed `lint` to show all errors as warnings and `--fix` to fix the issues that it has the capability to
- Updated `README.md` with current SwiftLint workflow
- Updated PR template to reflect current SwiftLint workflow

## Discussion
- Do we want this to perform `--fix`? Alternatively, since this is in the run scripts now, we can just have it `lint` and have programmers fix the errors. Thoughts?

## Checklist
- [X] I have implemented all requirements for this PR and its accompanying issue.
- [X] I have verified my implementation across all edge cases.
- [X] I have ensured my changes compile on macOS & iOS.
- [X] I executed `swiftlint --fix` on my code for cleanness.
