### PR TITLE
Add new home header

### DIFF
--- a/CanvasPlusPlayground/CanvasPlusPlaygroundApp.swift
+++ b/CanvasPlusPlayground/CanvasPlusPlaygroundApp.swift
@@ -38,14 +38,16 @@ struct CanvasPlusPlaygroundApp: App {
 
         #if os(macOS)
         Settings {
-            SettingsView()
-                .environment(profileManager)
-                .environment(courseManager)
-                .environment(pinnedItemsManager)
-                .environment(navigationModel)
-                .environmentObject(intelligenceManager)
-                .environmentObject(llmEvaluator)
-                .frame(width: 400, height: 500)
+            NavigationStack {
+                SettingsView()
+                    .environment(profileManager)
+                    .environment(courseManager)
+                    .environment(pinnedItemsManager)
+                    .environment(navigationModel)
+                    .environmentObject(intelligenceManager)
+                    .environmentObject(llmEvaluator)
+                    .frame(width: 400, height: 500)
+            }
         }
         #endif
     }

--- a/CanvasPlusPlayground/CanvasPlusPlaygroundApp.swift
+++ b/CanvasPlusPlayground/CanvasPlusPlaygroundApp.swift
@@ -40,14 +40,14 @@ struct CanvasPlusPlaygroundApp: App {
         Settings {
             NavigationStack {
                 SettingsView()
-                    .environment(profileManager)
-                    .environment(courseManager)
-                    .environment(pinnedItemsManager)
-                    .environment(navigationModel)
-                    .environmentObject(intelligenceManager)
-                    .environmentObject(llmEvaluator)
-                    .frame(width: 400, height: 500)
             }
+            .environment(profileManager)
+            .environment(courseManager)
+            .environment(pinnedItemsManager)
+            .environment(navigationModel)
+            .environmentObject(intelligenceManager)
+            .environmentObject(llmEvaluator)
+            .frame(width: 400, height: 500)
         }
         #endif
     }

--- a/CanvasPlusPlayground/Features/Navigation/HomeView.swift
+++ b/CanvasPlusPlayground/Features/Navigation/HomeView.swift
@@ -46,6 +46,9 @@ struct HomeView: View {
                 }
         } content: {
             contentView
+            #if os(iOS)
+                .navigationBarTitleDisplayMode(.large)
+            #endif
         } detail: {
             if let selectedCourse, let selectedCoursePage {
                 CourseDetailView(

--- a/CanvasPlusPlayground/Features/Navigation/HomeView.swift
+++ b/CanvasPlusPlayground/Features/Navigation/HomeView.swift
@@ -82,14 +82,16 @@ struct HomeView: View {
                 NavigationStack {
                     ProfileView(
                         user: currentUser,
-                        showCommonCourses: false
+                        isCurrentUser: true
                     )
                 }
             }
         }
         #if os(iOS)
         .sheet(isPresented: $navigationModel.showSettingsSheet) {
-            SettingsView()
+            NavigationStack {
+                SettingsView()
+            }
         }
         #endif
         .environment(navigationModel)

--- a/CanvasPlusPlayground/Features/Navigation/HomeView.swift
+++ b/CanvasPlusPlayground/Features/Navigation/HomeView.swift
@@ -87,13 +87,6 @@ struct HomeView: View {
                 }
             }
         }
-        #if os(iOS)
-        .sheet(isPresented: $navigationModel.showSettingsSheet) {
-            NavigationStack {
-                SettingsView()
-            }
-        }
-        #endif
         .environment(navigationModel)
     }
 

--- a/CanvasPlusPlayground/Features/Navigation/Sidebar.swift
+++ b/CanvasPlusPlayground/Features/Navigation/Sidebar.swift
@@ -9,16 +9,16 @@ import SwiftUI
 
 struct Sidebar: View {
     typealias NavigationPage = NavigationModel.NavigationPage
-    
+
     @Environment(NavigationModel.self) private var navigationModel
     @Environment(CourseManager.self) private var courseManager
     @Environment(ProfileManager.self) private var profileManager
-    
+
     @State private var isHiddenSectionExpanded: Bool = false
-    
+
     var body: some View {
         @Bindable var navigationModel = navigationModel
-        
+
         List(selection: $navigationModel.selectedNavigationPage) {
             #if os(iOS)
             Section {
@@ -27,11 +27,11 @@ struct Sidebar: View {
                     .listRowBackground(Color.clear)
             }
             #endif
-            
+
             Section {
                 SidebarTiles()
             }
-            
+
             Section("Favorites") {
                 ForEach(courseManager.userFavCourses) { course in
                     NavigationLink(
@@ -42,7 +42,7 @@ struct Sidebar: View {
                     .listItemTint(.fixed(course.rgbColors?.color ?? .accentColor))
                 }
             }
-            
+
             Section("My Courses") {
                 ForEach(courseManager.userOtherCourses) { course in
                     NavigationLink(value: NavigationPage.course(id: course.id)) {
@@ -51,7 +51,7 @@ struct Sidebar: View {
                     .listItemTint(.fixed(course.rgbColors?.color ?? .accentColor))
                 }
             }
-            
+
             if !courseManager.userHiddenCourses.isEmpty {
                 Section("Hidden", isExpanded: $isHiddenSectionExpanded) {
                     ForEach(courseManager.userHiddenCourses) { course in
@@ -63,17 +63,8 @@ struct Sidebar: View {
                 }
             }
         }
-        .listSectionSpacing(16)
-        .padding(.top, -24)
         .navigationTitle("Home")
-        .navigationBarTitleDisplayMode(.inline)
-        .toolbar {
-            ToolbarItem(placement: .principal) {
-                Rectangle()
-                    .fill(.clear)
-            }
-        }
-#if os(macOS)
+        #if os(macOS)
         .navigationSplitViewColumnWidth(min: 275, ideal: 275)
         .toolbar {
             ToolbarItem(placement: .confirmationAction) {
@@ -81,41 +72,48 @@ struct Sidebar: View {
                     Button {
                         navigationModel.showProfileSheet.toggle()
                     } label: {
-#if os(macOS)
                         ProfilePicture(user: currentUser, size: 19)
-#else
-                        ProfilePicture(user: currentUser, size: 24)
-#endif
                     }
                 }
             }
         }
-#endif
+        #else
+        .toolbar {
+            ToolbarItem(placement: .principal) {
+                Rectangle()
+                    .fill(.clear)
+            }
+        }
+        .padding(.top, -24)
+        .listSectionSpacing(16)
+        .navigationBarTitleDisplayMode(.inline)
+        #endif
     }
 }
 
+#if os(iOS)
 private struct SidebarHeader: View {
     @Environment(ProfileManager.self) private var profileManager
     @Environment(NavigationModel.self) private var navigationModel
-    
+
     private var formattedDate: String {
         let formatter = DateFormatter()
         formatter.dateFormat = "EEEE, MMMM d"
         return formatter.string(from: Date())
     }
-    
+
     var body: some View {
         VStack(alignment: .leading, spacing: 2) {
             Text(formattedDate)
                 .font(.body.bold())
                 .textCase(.uppercase)
                 .foregroundStyle(.secondary)
-            
+
             HStack(alignment: .top) {
                 Text("Home")
                     .font(.largeTitle.bold())
                 Spacer()
-                
+
                 if let currentUser = profileManager.currentUser {
                     Button {
                         navigationModel.showProfileSheet.toggle()
@@ -127,6 +125,7 @@ private struct SidebarHeader: View {
         }
     }
 }
+#endif
 
 private struct SidebarTiles: View {
     @Environment(NavigationModel.self) private var navigationModel

--- a/CanvasPlusPlayground/Features/Navigation/Sidebar.swift
+++ b/CanvasPlusPlayground/Features/Navigation/Sidebar.swift
@@ -142,7 +142,7 @@ private struct SidebarTiles: View {
             count: 2
         )
 #endif
-        
+
         return LazyVGrid(
             columns: columns,
             spacing: 4
@@ -155,7 +155,7 @@ private struct SidebarTiles: View {
             ) {
                 navigationModel.selectedNavigationPage = .announcements
             }
-            
+
             SidebarTile(
                 "To-Do",
                 systemIcon: "list.bullet.circle.fill",
@@ -164,7 +164,7 @@ private struct SidebarTiles: View {
             ) {
                 navigationModel.selectedNavigationPage = .toDoList
             }
-            
+
             SidebarTile(
                 "Pinned",
                 systemIcon: "pin.circle.fill",

--- a/CanvasPlusPlayground/Features/Navigation/Sidebar.swift
+++ b/CanvasPlusPlayground/Features/Navigation/Sidebar.swift
@@ -72,7 +72,7 @@ struct Sidebar: View {
                     Button {
                         navigationModel.showProfileSheet.toggle()
                     } label: {
-                        ProfilePicture(user: currentUser, size: 19)
+                        ProfilePicture(user: currentUser, size: 20)
                     }
                 }
             }
@@ -129,7 +129,7 @@ private struct SidebarHeader: View {
 
 private struct SidebarTiles: View {
     @Environment(NavigationModel.self) private var navigationModel
-    
+
     var body: some View {
 #if os(macOS)
         let columns = Array(

--- a/CanvasPlusPlayground/Features/Navigation/Sidebar.swift
+++ b/CanvasPlusPlayground/Features/Navigation/Sidebar.swift
@@ -23,7 +23,7 @@ struct Sidebar: View {
             #if os(iOS)
             Section {
                 SidebarHeader()
-                    .listRowInsets(EdgeInsets())
+                    .listRowInsets(EdgeInsets(top: 0, leading: 4.0, bottom: 0, trailing: 8.0))
                     .listRowBackground(Color.clear)
             }
             #endif
@@ -84,7 +84,7 @@ struct Sidebar: View {
                     .fill(.clear)
             }
         }
-        .padding(.top, -24)
+        .contentMargins(.top, 0)
         .listSectionSpacing(16)
         .navigationBarTitleDisplayMode(.inline)
         #endif

--- a/CanvasPlusPlayground/Features/Profile/ProfilePicture.swift
+++ b/CanvasPlusPlayground/Features/Profile/ProfilePicture.swift
@@ -16,7 +16,7 @@ private typealias PlatformImage = UIImage
 struct ProfilePicture: View {
     let user: User
     var size: CGFloat
-
+    
     internal init(user: User, size: CGFloat) {
         assert(size > 0, "Size must be greater than 0")
 
@@ -47,8 +47,8 @@ struct ProfilePicture: View {
         .overlay {
             if user.hasAvatar {
                 Circle()
-                    .strokeBorder(Color(white: 0.35), lineWidth: size/40.0)
-                    .blendMode(.luminosity)
+                    .strokeBorder(lineWidth: 1)
+                    .fill(.separator)
             }
         }
         .task {

--- a/CanvasPlusPlayground/Features/Profile/ProfilePicture.swift
+++ b/CanvasPlusPlayground/Features/Profile/ProfilePicture.swift
@@ -17,6 +17,13 @@ struct ProfilePicture: View {
     let user: User
     var size: CGFloat
 
+    internal init(user: User, size: CGFloat) {
+        assert(size > 0, "Size must be greater than 0")
+
+        self.user = user
+        self.size = size
+    }
+
     var body: some View {
         Group {
             if user.hasAvatar,
@@ -40,8 +47,8 @@ struct ProfilePicture: View {
         .overlay {
             if user.hasAvatar {
                 Circle()
-                    .stroke(lineWidth: 1)
-                    .fill(.separator)
+                    .strokeBorder(Color(white: 0.35), lineWidth: size/40.0)
+                    .blendMode(.luminosity)
             }
         }
         .task {

--- a/CanvasPlusPlayground/Features/Profile/ProfilePicture.swift
+++ b/CanvasPlusPlayground/Features/Profile/ProfilePicture.swift
@@ -17,7 +17,7 @@ struct ProfilePicture: View {
     let user: User
     var size: CGFloat
 
-    internal init(user: User, size: CGFloat) {
+    init(user: User, size: CGFloat) {
         assert(size > 0, "Size must be greater than 0")
 
         self.user = user

--- a/CanvasPlusPlayground/Features/Profile/ProfilePicture.swift
+++ b/CanvasPlusPlayground/Features/Profile/ProfilePicture.swift
@@ -43,6 +43,10 @@ struct ProfilePicture: View {
                     .font(.system(size: size))
             }
         }
+        .background {
+            Circle()
+                .fill(.separator)
+        }
         .frame(width: size, height: size)
         .task {
             guard user.hasAvatar, let url = user.avatarURL else { return }

--- a/CanvasPlusPlayground/Features/Profile/ProfilePicture.swift
+++ b/CanvasPlusPlayground/Features/Profile/ProfilePicture.swift
@@ -16,7 +16,7 @@ private typealias PlatformImage = UIImage
 struct ProfilePicture: View {
     let user: User
     var size: CGFloat
-    
+
     internal init(user: User, size: CGFloat) {
         assert(size > 0, "Size must be greater than 0")
 
@@ -44,13 +44,6 @@ struct ProfilePicture: View {
             }
         }
         .frame(width: size, height: size)
-        .overlay {
-            if user.hasAvatar {
-                Circle()
-                    .strokeBorder(lineWidth: 1)
-                    .fill(.separator)
-            }
-        }
         .task {
             guard user.hasAvatar, let url = user.avatarURL else { return }
 

--- a/CanvasPlusPlayground/Features/Profile/ProfileView.swift
+++ b/CanvasPlusPlayground/Features/Profile/ProfileView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct ProfileView: View {
     @Environment(ProfileManager.self) private var profileManager
+    @Environment(NavigationModel.self) var navigationModel
     @Environment(\.dismiss) private var dismiss
 
     let user: User
@@ -31,18 +32,30 @@ struct ProfileView: View {
     }
 
     var body: some View {
+        @Bindable var navigationModel = navigationModel
+
         Form {
             Section {
                 header
                     .listRowBackground(Color.clear)
             }
 
-            details
+            Section {
+                details
+            }
 
-            if isCurrentUser {
-                SettingsView()
-            } else {
-                PeopleCommonView(user: user)
+            Section {
+                if isCurrentUser {
+                    #if os(iOS)
+                    Button {
+                        navigationModel.showSettingsSheet = true
+                    } label: {
+                        Label("Settings", systemImage: "gearshape")
+                    }
+                    #endif
+                } else {
+                    PeopleCommonView(user: user)
+                }
             }
         }
         .formStyle(.grouped)
@@ -54,7 +67,11 @@ struct ProfileView: View {
             }
         }
         .animation(.default, value: profile)
-        #if os(macOS)
+        #if os(iOS)
+        .navigationDestination(isPresented: $navigationModel.showSettingsSheet) {
+            SettingsView()
+        }
+        #else
         .frame(height: 500)
         #endif
     }
@@ -100,6 +117,7 @@ struct ProfileView: View {
         }
 
         LabeledContent("Short Name", value: user.shortName)
+            .multilineTextAlignment(.trailing)
 
         if !user.enrollmentRoles.isEmpty {
             LabeledContent(

--- a/CanvasPlusPlayground/Features/Profile/ProfileView.swift
+++ b/CanvasPlusPlayground/Features/Profile/ProfileView.swift
@@ -12,7 +12,7 @@ struct ProfileView: View {
     @Environment(\.dismiss) private var dismiss
 
     let user: User
-    var showCommonCourses: Bool = true
+    var isCurrentUser: Bool
 
     var profile: Profile? {
         if user.id == profileManager.currentUser?.id {
@@ -24,10 +24,10 @@ struct ProfileView: View {
 
     init(
         user: User,
-        showCommonCourses: Bool = true
+        isCurrentUser: Bool = false
     ) {
         self.user = user
-        self.showCommonCourses = showCommonCourses
+        self.isCurrentUser = isCurrentUser
     }
 
     var body: some View {
@@ -39,7 +39,9 @@ struct ProfileView: View {
 
             details
 
-            if showCommonCourses {
+            if isCurrentUser {
+                SettingsView()
+            } else {
                 PeopleCommonView(user: user)
             }
         }

--- a/CanvasPlusPlayground/Features/Settings/SettingsView.swift
+++ b/CanvasPlusPlayground/Features/Settings/SettingsView.swift
@@ -21,41 +21,29 @@ struct SettingsView: View {
     var body: some View {
         @Bindable var navigationModel = navigationModel
 
-        NavigationStack {
-            mainBody
-        }
-        .sheet(isPresented: $showChangeAccessToken) {
-            NavigationStack {
-                SetupView()
+        mainBody
+            .sheet(isPresented: $showChangeAccessToken) {
+                NavigationStack {
+                    SetupView()
+                }
             }
-        }
-        .sheet(isPresented: $navigationModel.showInstallIntelligenceSheet, content: {
-            NavigationStack {
-                IntelligenceOnboardingView()
-            }
-            .environmentObject(llmEvaluator)
-            .environmentObject(intelligenceManager)
-            .interactiveDismissDisabled()
-        })
+            .sheet(isPresented: $navigationModel.showInstallIntelligenceSheet, content: {
+                NavigationStack {
+                    IntelligenceOnboardingView()
+                }
+                .environmentObject(llmEvaluator)
+                .environmentObject(intelligenceManager)
+                .interactiveDismissDisabled()
+            })
     }
 
+    @ViewBuilder
     private var mainBody: some View {
-        Form {
-            loginSettings
-            intelligenceSettings
-            #if DEBUG
-            debugSettings
-            #endif
-        }
-        .formStyle(.grouped)
-        #if os(iOS)
-        .toolbar {
-            ToolbarItem(placement: .confirmationAction) {
-                Button("Done") { dismiss() }
-            }
-        }
+        loginSettings
+        intelligenceSettings
+        #if DEBUG
+        debugSettings
         #endif
-        .navigationTitle("Settings")
     }
 
     private var loginSettings: some View {

--- a/CanvasPlusPlayground/Features/Settings/SettingsView.swift
+++ b/CanvasPlusPlayground/Features/Settings/SettingsView.swift
@@ -21,20 +21,23 @@ struct SettingsView: View {
     var body: some View {
         @Bindable var navigationModel = navigationModel
 
-        mainBody
-            .sheet(isPresented: $showChangeAccessToken) {
-                NavigationStack {
-                    SetupView()
-                }
+        Form {
+            mainBody
+        }
+        .navigationTitle("Settings")
+        .sheet(isPresented: $showChangeAccessToken) {
+            NavigationStack {
+                SetupView()
             }
-            .sheet(isPresented: $navigationModel.showInstallIntelligenceSheet, content: {
-                NavigationStack {
-                    IntelligenceOnboardingView()
-                }
-                .environmentObject(llmEvaluator)
-                .environmentObject(intelligenceManager)
-                .interactiveDismissDisabled()
-            })
+        }
+        .sheet(isPresented: $navigationModel.showInstallIntelligenceSheet, content: {
+            NavigationStack {
+                IntelligenceOnboardingView()
+            }
+            .environmentObject(llmEvaluator)
+            .environmentObject(intelligenceManager)
+            .interactiveDismissDisabled()
+        })
     }
 
     @ViewBuilder

--- a/CanvasPlusPlayground/Features/Settings/SettingsView.swift
+++ b/CanvasPlusPlayground/Features/Settings/SettingsView.swift
@@ -21,32 +21,32 @@ struct SettingsView: View {
     var body: some View {
         @Bindable var navigationModel = navigationModel
 
-        Form {
-            mainBody
-        }
-        .navigationTitle("Settings")
-        .sheet(isPresented: $showChangeAccessToken) {
-            NavigationStack {
-                SetupView()
+        mainBody
+            .navigationTitle("Settings")
+            .sheet(isPresented: $showChangeAccessToken) {
+                NavigationStack {
+                    SetupView()
+                }
             }
-        }
-        .sheet(isPresented: $navigationModel.showInstallIntelligenceSheet, content: {
-            NavigationStack {
-                IntelligenceOnboardingView()
-            }
-            .environmentObject(llmEvaluator)
-            .environmentObject(intelligenceManager)
-            .interactiveDismissDisabled()
-        })
+            .sheet(isPresented: $navigationModel.showInstallIntelligenceSheet, content: {
+                NavigationStack {
+                    IntelligenceOnboardingView()
+                }
+                .environmentObject(llmEvaluator)
+                .environmentObject(intelligenceManager)
+                .interactiveDismissDisabled()
+            })
     }
 
-    @ViewBuilder
     private var mainBody: some View {
-        loginSettings
-        intelligenceSettings
-        #if DEBUG
-        debugSettings
-        #endif
+        Form {
+            loginSettings
+            intelligenceSettings
+            #if DEBUG
+            debugSettings
+            #endif
+        }
+        .formStyle(.grouped)
     }
 
     private var loginSettings: some View {


### PR DESCRIPTION
## Changes Made

- Adds a new unified header design for the Home Screen inspired by apps like App Store and TV
- SwiftUI navigation stack is kept consistent
- The settings menu is now part of the user's profile menu, in iOS
- Current design is maintained in macOS

## Screenshots (if applicable)

<img width="360" alt="Screenshot 2025-02-15 at 4 44 40 PM" src="https://github.com/user-attachments/assets/bc156d12-8c4a-4e29-92e4-15c9532df9e2" />
<img width="360" alt="Screenshot 2025-02-15 at 4 44 50 PM" src="https://github.com/user-attachments/assets/84d289ec-5e7b-4767-b060-74656841ab23" />

<img width="360" alt="Screenshot 2025-02-15 at 9 20 19 PM" src="https://github.com/user-attachments/assets/125aa4c3-2695-486b-9066-ec4575b7b35a" />
<img width="360" alt="Screenshot 2025-02-15 at 9 20 21 PM" src="https://github.com/user-attachments/assets/9561f238-a07d-4e5b-b917-2fde55545c60" />

## Checklist
- [x] I have implemented all requirements for this PR and its accompanying issue.
- [x] I have verified my implementation across all edge cases.
- [x] I have ensured my changes compile on macOS & iOS.
- [x] I executed `swiftlint --fix` on my code for cleanness.
