### PR TITLE
assignment reminders

### DIFF
--- a/CanvasPlusPlayground.xcodeproj/project.pbxproj
+++ b/CanvasPlusPlayground.xcodeproj/project.pbxproj
@@ -20,7 +20,7 @@
 		9B6663E32C9853BC0060990E /* HTMLTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B6663E22C9853BC0060990E /* HTMLTextView.swift */; };
 		9B69FA4B2CC2CC7F006101F3 /* AggregatedAssignmentsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B69FA4A2CC2CC7F006101F3 /* AggregatedAssignmentsView.swift */; };
 		9B69FA4D2CC2CCB1006101F3 /* AggregatedAssignmentsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B69FA4C2CC2CCB1006101F3 /* AggregatedAssignmentsViewModel.swift */; };
-		9B69FA4F2CC2CCCF006101F3 /* AggregatedAssignmentsViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B69FA4E2CC2CCCF006101F3 /* AggregatedAssignmentsViewCell.swift */; };
+		9B69FA4F2CC2CCCF006101F3 /* AggregatedAssignmentsListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B69FA4E2CC2CCCF006101F3 /* AggregatedAssignmentsListCell.swift */; };
 		9B6D4F802D6E48340033044F /* ReminderButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B6D4F7F2D6E48340033044F /* ReminderButton.swift */; };
 		9B92A4232C93853C00C21CFC /* Announcement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B92A4222C93853C00C21CFC /* Announcement.swift */; };
 		9B92A4252C93856100C21CFC /* CourseAnnouncementManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B92A4242C93856100C21CFC /* CourseAnnouncementManager.swift */; };
@@ -181,7 +181,7 @@
 		9B6663E22C9853BC0060990E /* HTMLTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTMLTextView.swift; sourceTree = "<group>"; };
 		9B69FA4A2CC2CC7F006101F3 /* AggregatedAssignmentsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AggregatedAssignmentsView.swift; sourceTree = "<group>"; };
 		9B69FA4C2CC2CCB1006101F3 /* AggregatedAssignmentsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AggregatedAssignmentsViewModel.swift; sourceTree = "<group>"; };
-		9B69FA4E2CC2CCCF006101F3 /* AggregatedAssignmentsViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AggregatedAssignmentsViewCell.swift; sourceTree = "<group>"; };
+		9B69FA4E2CC2CCCF006101F3 /* AggregatedAssignmentsListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AggregatedAssignmentsListCell.swift; sourceTree = "<group>"; };
 		9B6D4F7F2D6E48340033044F /* ReminderButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReminderButton.swift; sourceTree = "<group>"; };
 		9B92A4222C93853C00C21CFC /* Announcement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Announcement.swift; sourceTree = "<group>"; };
 		9B92A4242C93856100C21CFC /* CourseAnnouncementManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseAnnouncementManager.swift; sourceTree = "<group>"; };

--- a/CanvasPlusPlayground.xcodeproj/project.pbxproj
+++ b/CanvasPlusPlayground.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		95BA93482C9CE20D00137A91 /* CalendarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95BA93472C9CE20D00137A91 /* CalendarView.swift */; };
 		9A977E832D6C322F001D7F0A /* LoggerService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A977E822D6C322F001D7F0A /* LoggerService.swift */; };
 		9A977E8B2D6C375E001D7F0A /* ColorPickerSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A977E8A2D6C375E001D7F0A /* ColorPickerSheet.swift */; };
+		9B07E7122D779CAB00359B69 /* Date+RelativeDates.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B07E7112D779CA500359B69 /* Date+RelativeDates.swift */; };
 		9B350F082C9652C6003FC60D /* NSAttributedString+HTML.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B350F072C9652C6003FC60D /* NSAttributedString+HTML.swift */; };
 		9B6663E32C9853BC0060990E /* HTMLTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B6663E22C9853BC0060990E /* HTMLTextView.swift */; };
 		9B69FA4B2CC2CC7F006101F3 /* AggregatedAssignmentsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B69FA4A2CC2CC7F006101F3 /* AggregatedAssignmentsView.swift */; };
@@ -177,6 +178,7 @@
 		95BA93472C9CE20D00137A91 /* CalendarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarView.swift; sourceTree = "<group>"; };
 		9A977E822D6C322F001D7F0A /* LoggerService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggerService.swift; sourceTree = "<group>"; };
 		9A977E8A2D6C375E001D7F0A /* ColorPickerSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorPickerSheet.swift; sourceTree = "<group>"; };
+		9B07E7112D779CA500359B69 /* Date+RelativeDates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+RelativeDates.swift"; sourceTree = "<group>"; };
 		9B350F072C9652C6003FC60D /* NSAttributedString+HTML.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSAttributedString+HTML.swift"; sourceTree = "<group>"; };
 		9B6663E22C9853BC0060990E /* HTMLTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTMLTextView.swift; sourceTree = "<group>"; };
 		9B69FA4A2CC2CC7F006101F3 /* AggregatedAssignmentsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AggregatedAssignmentsView.swift; sourceTree = "<group>"; };
@@ -468,6 +470,7 @@
 		A324BA552D0796BE005F53FA /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
+				9B07E7112D779CA500359B69 /* Date+RelativeDates.swift */,
 				A373DC0E2D19F71600215019 /* TypeSafeCodable.swift */,
 				A3CF88D22D18E6BB000ACDF3 /* ParentKeyPath.swift */,
 				B7F950312D118EAA004BB470 /* String+StripHTML.swift */,
@@ -1009,6 +1012,7 @@
 				B76455062C8DF61B002DF00E /* CanvasPlusPlaygroundApp.swift in Sources */,
 				B7F950342D11A00F004BB470 /* StatusToolbarItem.swift in Sources */,
 				A301EE0F2D612EA800D71139 /* DiscussionTopic.swift in Sources */,
+				9B07E7122D779CAB00359B69 /* Date+RelativeDates.swift in Sources */,
 				9B69FA4B2CC2CC7F006101F3 /* AggregatedAssignmentsView.swift in Sources */,
 				B7C0A3BF2D2F2251003E5A36 /* PinnedItemsView.swift in Sources */,
 				A3CF88E32D1921CB000ACDF3 /* FolderAPI.swift in Sources */,

--- a/CanvasPlusPlayground.xcodeproj/project.pbxproj
+++ b/CanvasPlusPlayground.xcodeproj/project.pbxproj
@@ -20,12 +20,14 @@
 		9B69FA4B2CC2CC7F006101F3 /* AggregatedAssignmentsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B69FA4A2CC2CC7F006101F3 /* AggregatedAssignmentsView.swift */; };
 		9B69FA4D2CC2CCB1006101F3 /* AggregatedAssignmentsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B69FA4C2CC2CCB1006101F3 /* AggregatedAssignmentsViewModel.swift */; };
 		9B69FA4F2CC2CCCF006101F3 /* AggregatedAssignmentsViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B69FA4E2CC2CCCF006101F3 /* AggregatedAssignmentsViewCell.swift */; };
+		9B6D4F802D6E48340033044F /* ReminderButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B6D4F7F2D6E48340033044F /* ReminderButton.swift */; };
 		9B92A4232C93853C00C21CFC /* Announcement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B92A4222C93853C00C21CFC /* Announcement.swift */; };
 		9B92A4252C93856100C21CFC /* CourseAnnouncementManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B92A4242C93856100C21CFC /* CourseAnnouncementManager.swift */; };
 		9B9C2E042C93F6CD00E4B16B /* CourseAnnouncementsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B9C2E032C93F6CD00E4B16B /* CourseAnnouncementsView.swift */; };
 		9B9C2E062C93F94C00E4B16B /* CourseAnnouncementDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B9C2E052C93F94C00E4B16B /* CourseAnnouncementDetailView.swift */; };
 		9BA7C0F72D62DC92000F2918 /* PinnedItemDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BA7C0F62D62DC92000F2918 /* PinnedItemDetailView.swift */; };
 		9BEB4ED02D56AF570013869D /* AssignmentDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BEB4ECF2D56AF570013869D /* AssignmentDetailView.swift */; };
+		9BF228C82D6CD1EB000676F2 /* RemindersManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BF228C72D6CD1EB000676F2 /* RemindersManager.swift */; };
 		A301EE092D61137400D71139 /* MarkCourseDiscussionTopicReadRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = A301EE082D61137400D71139 /* MarkCourseDiscussionTopicReadRequest.swift */; };
 		A301EE0B2D61148C00D71139 /* MarkCourseDiscussionTopicUnreadRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = A301EE0A2D61148C00D71139 /* MarkCourseDiscussionTopicUnreadRequest.swift */; };
 		A301EE0D2D612E7100D71139 /* DiscussionTopicAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = A301EE0C2D612E7100D71139 /* DiscussionTopicAPI.swift */; };
@@ -179,12 +181,14 @@
 		9B69FA4A2CC2CC7F006101F3 /* AggregatedAssignmentsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AggregatedAssignmentsView.swift; sourceTree = "<group>"; };
 		9B69FA4C2CC2CCB1006101F3 /* AggregatedAssignmentsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AggregatedAssignmentsViewModel.swift; sourceTree = "<group>"; };
 		9B69FA4E2CC2CCCF006101F3 /* AggregatedAssignmentsViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AggregatedAssignmentsViewCell.swift; sourceTree = "<group>"; };
+		9B6D4F7F2D6E48340033044F /* ReminderButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReminderButton.swift; sourceTree = "<group>"; };
 		9B92A4222C93853C00C21CFC /* Announcement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Announcement.swift; sourceTree = "<group>"; };
 		9B92A4242C93856100C21CFC /* CourseAnnouncementManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseAnnouncementManager.swift; sourceTree = "<group>"; };
 		9B9C2E032C93F6CD00E4B16B /* CourseAnnouncementsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseAnnouncementsView.swift; sourceTree = "<group>"; };
 		9B9C2E052C93F94C00E4B16B /* CourseAnnouncementDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseAnnouncementDetailView.swift; sourceTree = "<group>"; };
 		9BA7C0F62D62DC92000F2918 /* PinnedItemDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinnedItemDetailView.swift; sourceTree = "<group>"; };
 		9BEB4ECF2D56AF570013869D /* AssignmentDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssignmentDetailView.swift; sourceTree = "<group>"; };
+		9BF228C72D6CD1EB000676F2 /* RemindersManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemindersManager.swift; sourceTree = "<group>"; };
 		A301EE082D61137400D71139 /* MarkCourseDiscussionTopicReadRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkCourseDiscussionTopicReadRequest.swift; sourceTree = "<group>"; };
 		A301EE0A2D61148C00D71139 /* MarkCourseDiscussionTopicUnreadRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkCourseDiscussionTopicUnreadRequest.swift; sourceTree = "<group>"; };
 		A301EE0C2D612E7100D71139 /* DiscussionTopicAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscussionTopicAPI.swift; sourceTree = "<group>"; };
@@ -336,6 +340,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		9BF228C62D6CD1DF000676F2 /* Reminders */ = {
+			isa = PBXGroup;
+			children = (
+				9BF228C72D6CD1EB000676F2 /* RemindersManager.swift */,
+				9B6D4F7F2D6E48340033044F /* ReminderButton.swift */,
+			);
+			path = Reminders;
+			sourceTree = "<group>";
+		};
 		A3049B642D0F3E26002F3166 /* Quiz */ = {
 			isa = PBXGroup;
 			children = (
@@ -379,6 +392,7 @@
 		A324BA502D07963D005F53FA /* Features */ = {
 			isa = PBXGroup;
 			children = (
+				9BF228C62D6CD1DF000676F2 /* Reminders */,
 				A373DC2E2D28174700215019 /* Modules */,
 				B7C5532A2D2D5AEB009CF4F0 /* Pinned Items */,
 				B7E59A0E2D200281001836FE /* Navigation */,
@@ -915,6 +929,7 @@
 				A301EE0D2D612E7100D71139 /* DiscussionTopicAPI.swift in Sources */,
 				A373DC252D1D4BEC00215019 /* APIQuizSubmission.swift in Sources */,
 				B7C0A3CF2D31F339003E5A36 /* PinnedItemCard.swift in Sources */,
+				9BF228C82D6CD1EB000676F2 /* RemindersManager.swift in Sources */,
 				B7D95D772D07C3D3002AD955 /* ICSParser.swift in Sources */,
 				A3CF88D32D18E6BB000ACDF3 /* ParentKeyPath.swift in Sources */,
 				B7F9503B2D127AD0004BB470 /* ProfileAPI.swift in Sources */,
@@ -988,6 +1003,7 @@
 				B77FD0072D5309340049AA5E /* ProfilePicture.swift in Sources */,
 				A35191412D283589001E415F /* ModulesViewModel.swift in Sources */,
 				A3E7F3912C99317100DC4300 /* CourseTabsManager.swift in Sources */,
+				9B6D4F802D6E48340033044F /* ReminderButton.swift in Sources */,
 				A3E7F38F2C96C1CE00DC4300 /* CourseTabsView.swift in Sources */,
 				B76455062C8DF61B002DF00E /* CanvasPlusPlaygroundApp.swift in Sources */,
 				B7F950342D11A00F004BB470 /* StatusToolbarItem.swift in Sources */,

--- a/CanvasPlusPlayground/CanvasPlusPlaygroundApp.swift
+++ b/CanvasPlusPlayground/CanvasPlusPlaygroundApp.swift
@@ -20,7 +20,6 @@ struct CanvasPlusPlaygroundApp: App {
     // Intelligence
     @StateObject private var intelligenceManager = IntelligenceManager()
     @StateObject private var llmEvaluator = LLMEvaluator()
-
     var body: some Scene {
         WindowGroup {
             HomeView()

--- a/CanvasPlusPlayground/CanvasPlusPlaygroundApp.swift
+++ b/CanvasPlusPlayground/CanvasPlusPlaygroundApp.swift
@@ -16,7 +16,7 @@ struct CanvasPlusPlaygroundApp: App {
     @State private var profileManager = ProfileManager()
     @State private var courseManager = CourseManager()
     @State private var pinnedItemsManager = PinnedItemsManager()
-
+    @State private var remindersManager = RemindersManager()
     // Intelligence
     @StateObject private var intelligenceManager = IntelligenceManager()
     @StateObject private var llmEvaluator = LLMEvaluator()
@@ -28,6 +28,7 @@ struct CanvasPlusPlaygroundApp: App {
                 .environment(courseManager)
                 .environment(pinnedItemsManager)
                 .environment(navigationModel)
+                .environment(remindersManager)
                 .environmentObject(intelligenceManager)
                 .environmentObject(llmEvaluator)
                 .task {

--- a/CanvasPlusPlayground/Common/Utilities/Date+RelativeDates.swift
+++ b/CanvasPlusPlayground/Common/Utilities/Date+RelativeDates.swift
@@ -1,0 +1,43 @@
+//
+//  Date+RelativeDates.swift
+//  CanvasPlusPlayground
+//
+//  Created by Ethan Fox on 3/4/25.
+//
+import Foundation
+
+extension Date {
+    func dayOfWeekString() -> String {
+        let date = self
+        let formatter = DateFormatter()
+        formatter.dateFormat = "EEE"
+        return formatter.string(from: date)
+    }
+
+    static var tomorrowAt8am: Date {
+        let calendar = Calendar.current
+        let now = Date.now
+
+        guard let tomorrow = calendar.date(byAdding: .day, value: 1, to: now)  else {
+            return Date.now
+        }
+
+        let tomorrowAt8AM = calendar.date(bySettingHour: 8, minute: 0, second: 0, of: tomorrow)
+        return tomorrowAt8AM ?? Date.now
+    }
+
+    static func nextOrdinalAt8am(weekday: Int) -> Date {
+        if weekday < 1 || weekday > 7 {
+            return .now
+        }
+        let calendar = Calendar.current
+        let now = Date.now
+
+        // Find the next ordinal day
+        guard let nextDay = calendar.nextDate(after: now, matching: DateComponents(weekday: weekday), matchingPolicy: .nextTime) else {
+            return Date.now
+        }
+        // Set the time to 8 AM
+        return calendar.date(bySettingHour: 8, minute: 0, second: 0, of: nextDay) ?? Date.now
+    }
+}

--- a/CanvasPlusPlayground/Features/Assignments/AssignmentDetailView.swift
+++ b/CanvasPlusPlayground/Features/Assignments/AssignmentDetailView.swift
@@ -80,6 +80,9 @@ struct AssignmentDetailView: View {
                 }
             }
             .formStyle(.grouped)
+            .toolbar {
+                ReminderButton(item: .assignment(assignment))
+            }
             .task {
                 submission = assignment.submission?.createModel()
             }

--- a/CanvasPlusPlayground/Features/Assignments/Models/Assignment.swift
+++ b/CanvasPlusPlayground/Features/Assignments/Models/Assignment.swift
@@ -270,4 +270,6 @@ class Assignment: Cacheable {
         case gpaScale = "gpa_scale"
         case points = "points"
     }
+
+    static let example: Assignment = Assignment(from: .example)
 }

--- a/CanvasPlusPlayground/Features/Assignments/Models/Assignment.swift
+++ b/CanvasPlusPlayground/Features/Assignments/Models/Assignment.swift
@@ -273,5 +273,5 @@ class Assignment: Cacheable {
         case points = "points"
     }
 
-    static let example: Assignment = Assignment(from: .example)
+    static let example = Assignment(from: .example)
 }

--- a/CanvasPlusPlayground/Features/Reminders/ReminderButton.swift
+++ b/CanvasPlusPlayground/Features/Reminders/ReminderButton.swift
@@ -1,0 +1,170 @@
+//
+//  ReminderButton.swift
+//  CanvasPlusPlayground
+//
+//  Created by Ethan Fox on 2/25/25.
+//
+
+import SwiftUI
+
+let logger = LoggerService.main
+
+struct ReminderButton: View {
+    @Environment(RemindersManager.self) var reminderManager
+    @State var showPopUp = false
+    @State var rotate = false
+
+    let item: ReminderType
+
+    var reminderEnabled: Bool {
+        withAnimation {
+            reminderManager.itemHasReminder(item)
+        }
+    }
+
+    var body: some View {
+        Button {
+            if reminderEnabled {
+                reminderManager.removeReminder(for: item)
+            } else {
+                showPopUp.toggle()
+            }
+        } label: {
+            if #available(iOS 18.0, macOS 15.0, *) {
+                Image(systemName: reminderEnabled ? "bell.fill" : "bell")
+                    .symbolEffect(.wiggle, options: .speed(3), value: reminderEnabled) // no wiggles for the old phones :(
+            } else {
+                Image(systemName: reminderEnabled ? "bell.fill" : "bell")
+            }
+        }
+        .sheet(isPresented: $showPopUp) {
+            ReminderDatePicker(item: item)
+        }
+    }
+}
+
+struct ReminderDatePicker: View {
+    @Environment(RemindersManager.self) var reminderManager
+    @Environment(\.dismiss) var dismiss
+    @State var selectedDate: Date = .now
+
+    let item: ReminderType
+    let datePickerOptions: [(String, Color, String, Date)] =
+    [
+        ("bell", .yellow, "Tomorrow", .tomorrowAt8am),
+        ("sofa", .purple, "This Weekend", .nextOrdinalAt8am(weekday: 7)),
+        ("calendar.badge.clock", .green, "Next Week", .nextOrdinalAt8am(weekday: 1)) // Essentially, "next Monday"
+    ]
+
+    var body: some View {
+        VStack {
+            HStack {
+                Button("Cancel") {
+                    dismiss()
+                }
+                Spacer()
+                Button("Done") {
+                    Task {
+                        await reminderManager.scheduleReminder(for: item, at: selectedDate)
+                    }
+                    dismiss()
+                }
+            }
+            .padding(.bottom, 15)
+            Text("Set a Reminder")
+                .font(.headline)
+                .padding(.bottom, 15)
+            ForEach(datePickerOptions, id: \.0) { imageName, color, text, date in
+                QuickDateButton(
+                    imageName: imageName,
+                    imageColor: color,
+                    text: text,
+                    date: date)
+                {
+                    Task {
+                        await reminderManager.scheduleReminder(for: item, at: date)
+                    }
+                    dismiss()
+                }
+            }
+            DatePicker("Set reminder for:", selection: $selectedDate)
+            #if os(iOS)
+                .datePickerStyle(.graphical)
+            #endif
+            Spacer()
+        }
+        .padding()
+        .presentationDragIndicator(.visible)
+    }
+    
+    struct QuickDateButton: View {
+        let imageName: String
+        let imageColor: Color
+        let text: String
+        let date: Date
+        let action: () -> Void
+        
+        var body: some View {
+            Button(action: action) {
+                HStack {
+                    Image(systemName: imageName)
+                        .foregroundColor(imageColor)
+                        .imageScale(.large)
+                        .frame(maxWidth: 40)
+                        .bold()
+                    Text(text)
+                        .bold()
+                    Spacer()
+                    Text(date.dayOfWeekString())
+                        .textCase(.uppercase)
+                        .font(.callout)
+                        .opacity(0.75)
+                }
+            }
+            
+            .buttonStyle(.plain)
+            .padding([.leading], 5)
+            .padding([.trailing], 10)
+            .padding([.top, .bottom])
+            .background(.quaternary)
+            .cornerRadius(5)
+            
+        }
+    }
+}
+
+extension Date {
+    func dayOfWeekString() -> String {
+        let date = Date()
+        let formatter = DateFormatter()
+        formatter.dateFormat = "EEE"
+        return formatter.string(from: date)
+    }
+    
+    static var tomorrowAt8am: Date {
+        let calendar = Calendar.current
+        let now = Date()
+        
+        guard let tomorrow = calendar.date(byAdding: .day, value: 1, to: now)  else {
+            return Date.now
+        }
+        
+        let tomorrowAt8AM = calendar.date(bySettingHour: 8, minute: 0, second: 0, of: tomorrow)
+        return tomorrowAt8AM ?? Date.now
+    }
+    
+    static func nextOrdinalAt8am(weekday: Int) -> Date {
+        if weekday < 1 || weekday > 7 {
+            return .now
+        }
+        let calendar = Calendar.current
+        let now = Date()
+
+        // Find the next Saturday
+        guard let nextDay = calendar.nextDate(after: now, matching: DateComponents(weekday: weekday), matchingPolicy: .nextTime) else {
+            return Date.now
+        }
+        // Set the time to 8 AM
+        return calendar.date(bySettingHour: 8, minute: 0, second: 0, of: nextDay) ?? Date.now
+    }
+}

--- a/CanvasPlusPlayground/Features/Reminders/ReminderButton.swift
+++ b/CanvasPlusPlayground/Features/Reminders/ReminderButton.swift
@@ -7,8 +7,6 @@
 
 import SwiftUI
 
-let logger = LoggerService.main
-
 struct ReminderButton: View {
     @Environment(RemindersManager.self) var reminderManager
     @State var showPopUp = false

--- a/CanvasPlusPlayground/Features/Reminders/ReminderButton.swift
+++ b/CanvasPlusPlayground/Features/Reminders/ReminderButton.swift
@@ -53,7 +53,7 @@ struct ReminderDatePicker: View {
     [
         ("bell", .yellow, "Tomorrow", .tomorrowAt8am),
         ("sofa", .purple, "This Weekend", .nextOrdinalAt8am(weekday: 7)),
-        ("calendar.badge.clock", .green, "Next Week", .nextOrdinalAt8am(weekday: 1)) // Essentially, "next Monday"
+        ("calendar.badge.clock", .green, "Next Week", .nextOrdinalAt8am(weekday: 2)) // Essentially, "next Monday"
     ]
 
     var body: some View {
@@ -134,7 +134,7 @@ struct ReminderDatePicker: View {
 
 extension Date {
     func dayOfWeekString() -> String {
-        let date = Date()
+        let date = self
         let formatter = DateFormatter()
         formatter.dateFormat = "EEE"
         return formatter.string(from: date)

--- a/CanvasPlusPlayground/Features/Reminders/ReminderButton.swift
+++ b/CanvasPlusPlayground/Features/Reminders/ReminderButton.swift
@@ -49,6 +49,8 @@ struct ReminderDatePicker: View {
     @State var selectedDate: Date = .now
 
     let item: ReminderType
+
+    // SF Symbol Icon Name, Color of SF Symbol, Date Interval Text, Date Interval
     let datePickerOptions: [(String, Color, String, Date)] =
     [
         ("bell", .yellow, "Tomorrow", .tomorrowAt8am),

--- a/CanvasPlusPlayground/Features/Reminders/ReminderButton.swift
+++ b/CanvasPlusPlayground/Features/Reminders/ReminderButton.swift
@@ -69,7 +69,6 @@ private struct ReminderDatePicker: View {
                             date: date,
                             action: { scheduleReminder(date: date) })
                     }
-                    .padding([.leading, .trailing], 5)
                 }
                 Section("Custom") {
                     DatePicker("", selection: $selectedDate, in: Date.now...)
@@ -150,6 +149,7 @@ private struct ReminderDatePicker: View {
                 .padding([.leading], 5)
                 .padding([.trailing], 10)
                 .padding([.top, .bottom])
+                .contentShape(.rect)
             }
             .buttonStyle(.plain)
         }

--- a/CanvasPlusPlayground/Features/Reminders/ReminderButton.swift
+++ b/CanvasPlusPlayground/Features/Reminders/ReminderButton.swift
@@ -79,8 +79,7 @@ struct ReminderDatePicker: View {
                     imageName: imageName,
                     imageColor: color,
                     text: text,
-                    date: date)
-                {
+                    date: date) {
                     Task {
                         await reminderManager.scheduleReminder(for: item, at: date)
                     }
@@ -96,14 +95,14 @@ struct ReminderDatePicker: View {
         .padding()
         .presentationDragIndicator(.visible)
     }
-    
+
     struct QuickDateButton: View {
         let imageName: String
         let imageColor: Color
         let text: String
         let date: Date
         let action: () -> Void
-        
+
         var body: some View {
             Button(action: action) {
                 HStack {
@@ -121,14 +120,14 @@ struct ReminderDatePicker: View {
                         .opacity(0.75)
                 }
             }
-            
+
             .buttonStyle(.plain)
             .padding([.leading], 5)
             .padding([.trailing], 10)
             .padding([.top, .bottom])
             .background(.quaternary)
             .cornerRadius(5)
-            
+
         }
     }
 }
@@ -140,19 +139,19 @@ extension Date {
         formatter.dateFormat = "EEE"
         return formatter.string(from: date)
     }
-    
+
     static var tomorrowAt8am: Date {
         let calendar = Calendar.current
         let now = Date()
-        
+
         guard let tomorrow = calendar.date(byAdding: .day, value: 1, to: now)  else {
             return Date.now
         }
-        
+
         let tomorrowAt8AM = calendar.date(bySettingHour: 8, minute: 0, second: 0, of: tomorrow)
         return tomorrowAt8AM ?? Date.now
     }
-    
+
     static func nextOrdinalAt8am(weekday: Int) -> Date {
         if weekday < 1 || weekday > 7 {
             return .now

--- a/CanvasPlusPlayground/Features/Reminders/RemindersManager.swift
+++ b/CanvasPlusPlayground/Features/Reminders/RemindersManager.swift
@@ -79,7 +79,10 @@ class RemindersManager: NSObject, UNUserNotificationCenterDelegate {
         }
     }
 
-    func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification,
+        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
         reminders.removeAll { request in
             notification.request.identifier == request.identifier
         }

--- a/CanvasPlusPlayground/Features/Reminders/RemindersManager.swift
+++ b/CanvasPlusPlayground/Features/Reminders/RemindersManager.swift
@@ -8,8 +8,6 @@
 import Foundation
 import UserNotifications
 
-let logger = LoggerService.main
-
 @Observable
 class RemindersManager {
     var reminders: [UNNotificationRequest] = []
@@ -24,7 +22,7 @@ class RemindersManager {
         do {
             try await center.requestAuthorization(options: [.alert, .sound, .badge])
         } catch {
-            logger.error("Error requesting authorization: \(error)")
+            LoggerService.main.error("Error requesting authorization: \(error)")
         }
 
         let content = UNMutableNotificationContent()
@@ -51,7 +49,7 @@ class RemindersManager {
             try await center.add(request)
             self.reminders.append(request)
         } catch {
-            logger.error("Error adding notification: \(error)")
+            LoggerService.main.error("Error adding notification: \(error)")
         }
     }
 

--- a/CanvasPlusPlayground/Features/Reminders/RemindersManager.swift
+++ b/CanvasPlusPlayground/Features/Reminders/RemindersManager.swift
@@ -1,0 +1,94 @@
+//
+//  RemindersManager.swift
+//  CanvasPlusPlayground
+//
+//  Created by Ethan Fox on 2/24/25.
+//
+
+import Foundation
+import UserNotifications
+
+let logger = LoggerService.main
+
+@Observable
+class RemindersManager {
+    var reminders: [UNNotificationRequest] = []
+    var center = UNUserNotificationCenter.current()
+
+    
+    init() {
+        loadItems()
+    }
+    
+    func scheduleReminder(for item: ReminderType, at date: Date) async {
+        do {
+            try await center.requestAuthorization(options: [.alert, .sound, .badge])
+        } catch {
+            logger.error("Error requesting authorization: \(error)")
+        }
+
+        let content = UNMutableNotificationContent()
+        
+        switch item {
+            case .assignment(let assignment):
+            content.title = "REMINDER: \(assignment.name)"
+            // if the assignment has a due date, we want to let the user know how much time left
+            if let dueDate = assignment.dueDate {
+                let deltaText = timeDeltaString(from: dueDate, to: date)
+                content.body = "Assignment is due in \(deltaText)"
+            } else {
+                content.body = ""
+            }
+        }
+        
+        
+        content.sound = .default
+        let components = Calendar.current.dateComponents([.year, .month, .day, .hour, .minute], from: date)
+        let trigger = UNCalendarNotificationTrigger(dateMatching: components, repeats: false)
+        let request = UNNotificationRequest(identifier: item.reminderIdentifier, content: content, trigger: trigger)
+
+        do {
+            try await center.add(request)
+            self.reminders.append(request)
+        } catch {
+            logger.error("Error adding notification: \(error)")
+        }
+    }
+
+    func removeReminder(for item: ReminderType) {
+        center.removePendingNotificationRequests(withIdentifiers: [item.reminderIdentifier])
+        reminders.removeAll { request in
+            request.identifier == item.reminderIdentifier
+        }
+    }
+
+    func loadItems() {
+        Task {
+            self.reminders = await center.pendingNotificationRequests()
+        }
+    }
+    
+    func itemHasReminder(_ item: ReminderType) -> Bool {
+        reminders.contains { request in
+            request.identifier == item.reminderIdentifier
+        }
+    }
+}
+
+enum ReminderType: Equatable {
+    case assignment(Assignment)
+
+    var reminderIdentifier: String {
+        switch self {
+        case .assignment(let assignment):
+            return "assignment-\(assignment.id)"
+        }
+    }
+}
+
+func timeDeltaString(from startDate: Date, to endDate: Date) -> String {
+    let formatter = DateComponentsFormatter()
+    formatter.unitsStyle = .full // Use .short or .abbreviated for different styles
+    formatter.allowedUnits = [.day, .hour]
+    return formatter.string(from: startDate, to: endDate) ?? "N/A"
+}

--- a/CanvasPlusPlayground/Features/Reminders/RemindersManager.swift
+++ b/CanvasPlusPlayground/Features/Reminders/RemindersManager.swift
@@ -31,7 +31,7 @@ class RemindersManager {
             content.title = "REMINDER: \(assignment.name)"
             // if the assignment has a due date, we want to let the user know how much time left
             if let dueDate = assignment.dueDate {
-                let deltaText = timeDeltaString(from: dueDate, to: date)
+                let deltaText = Date.timeDeltaString(from: dueDate, to: date)
                 content.body = "Assignment is due in \(deltaText)"
             } else {
                 content.body = ""
@@ -82,9 +82,11 @@ enum ReminderType: Equatable {
     }
 }
 
-func timeDeltaString(from startDate: Date, to endDate: Date) -> String {
-    let formatter = DateComponentsFormatter()
-    formatter.unitsStyle = .full // Use .short or .abbreviated for different styles
-    formatter.allowedUnits = [.day, .hour]
-    return formatter.string(from: startDate, to: endDate) ?? "N/A"
+extension Date {
+    static func timeDeltaString(from startDate: Date, to endDate: Date) -> String {
+        let formatter = DateComponentsFormatter()
+        formatter.unitsStyle = .full // Use .short or .abbreviated for different styles
+        formatter.allowedUnits = [.day, .hour]
+        return formatter.string(from: startDate, to: endDate) ?? "N/A"
+    }
 }

--- a/CanvasPlusPlayground/Features/Reminders/RemindersManager.swift
+++ b/CanvasPlusPlayground/Features/Reminders/RemindersManager.swift
@@ -13,11 +13,10 @@ class RemindersManager {
     var reminders: [UNNotificationRequest] = []
     var center = UNUserNotificationCenter.current()
 
-    
     init() {
         loadItems()
     }
-    
+
     func scheduleReminder(for item: ReminderType, at date: Date) async {
         do {
             try await center.requestAuthorization(options: [.alert, .sound, .badge])
@@ -26,7 +25,7 @@ class RemindersManager {
         }
 
         let content = UNMutableNotificationContent()
-        
+
         switch item {
             case .assignment(let assignment):
             content.title = "REMINDER: \(assignment.name)"
@@ -38,8 +37,7 @@ class RemindersManager {
                 content.body = ""
             }
         }
-        
-        
+
         content.sound = .default
         let components = Calendar.current.dateComponents([.year, .month, .day, .hour, .minute], from: date)
         let trigger = UNCalendarNotificationTrigger(dateMatching: components, repeats: false)
@@ -65,7 +63,7 @@ class RemindersManager {
             self.reminders = await center.pendingNotificationRequests()
         }
     }
-    
+
     func itemHasReminder(_ item: ReminderType) -> Bool {
         reminders.contains { request in
             request.identifier == item.reminderIdentifier


### PR DESCRIPTION
Fixes #232 
## Changes Made

- Added a reminders manager which interfaces with `UNNotificationCenter`
    - Right now, you can only set reminders for assignments, but it is extensible to include other types
- Added a modal sheet/button for setting a reminder for an assignment (to remove reminder, just tap button again)

## Screenshots (if applicable)

https://github.com/user-attachments/assets/801e4920-0308-4da1-9eae-e742d909f896

https://github.com/user-attachments/assets/5aa22830-1f5f-43db-9c0b-d7a9e18dade6



## Checklist
- [x] I have implemented all requirements for this PR and its accompanying issue.
- [x] I have verified my implementation across all edge cases.
- [x] I have ensured my changes compile on macOS & iOS.
- [x] I have resolved all SwiftLint warnings.
