### PR TITLE
Remove favorite course functionality

### DIFF
--- a/CanvasPlusPlayground/Features/Announcements/AllAnnouncementsView.swift
+++ b/CanvasPlusPlayground/Features/Announcements/AllAnnouncementsView.swift
@@ -46,7 +46,7 @@ struct AllAnnouncementsView: View {
     private func loadAnnouncements() async {
         isLoadingAnnouncements = true
         await announcementsManager
-            .fetchAnnouncements(courses: courseManager.displayedCourses)
+            .fetchAnnouncements(courses: courseManager.userCourses)
         isLoadingAnnouncements = false
     }
 }

--- a/CanvasPlusPlayground/Features/Assignments/AggregatedAssignmentsView.swift
+++ b/CanvasPlusPlayground/Features/Assignments/AggregatedAssignmentsView.swift
@@ -24,7 +24,7 @@ struct AggregatedAssignmentsView: View {
         .navigationTitle("Your Assignments")
         .task {
             await viewModel
-                .loadAssignments(courses: courseManager.displayedCourses)
+                .loadAssignments(courses: courseManager.userCourses)
         }
     }
 }

--- a/CanvasPlusPlayground/Features/Courses/CourseManager.swift
+++ b/CanvasPlusPlayground/Features/Courses/CourseManager.swift
@@ -11,22 +11,14 @@ import SwiftUI
 class CourseManager {
     var allCourses = [Course]()
 
+    /// This list is used in `PeopleCommonView` and `AllAnnouncements`.
     var displayedCourses: [Course] {
-        allCourses
-            .filter { !($0.isHidden ?? false) }
+        userCourses
     }
 
-    var userFavCourses: [Course] {
+    var userCourses: [Course] {
         allCourses
             .filter { !($0.isHidden ?? false) }
-            .filter { $0.isFavorite }
-            .sorted { $0.name ?? "" < $1.name ?? "" }
-    }
-
-    var userOtherCourses: [Course] {
-        allCourses
-            .filter { !($0.isHidden ?? false) }
-            .filter { !($0.isFavorite) }
             .sorted { $0.name ?? "" < $1.name ?? "" }
     }
 

--- a/CanvasPlusPlayground/Features/Courses/CourseManager.swift
+++ b/CanvasPlusPlayground/Features/Courses/CourseManager.swift
@@ -12,17 +12,13 @@ class CourseManager {
     var allCourses = [Course]()
 
     /// This list is used in `PeopleCommonView` and `AllAnnouncements`.
-    var displayedCourses: [Course] {
-        userCourses
-    }
-
     var userCourses: [Course] {
         allCourses
             .filter { !($0.isHidden ?? false) }
             .sorted { $0.name ?? "" < $1.name ?? "" }
     }
 
-    var userHiddenCourses: [Course] {
+    var hiddenCourses: [Course] {
         allCourses
             .filter { $0.isHidden ?? false }
             .sorted { $0.name ?? "" < $1.name ?? "" }

--- a/CanvasPlusPlayground/Features/Courses/Models/Course.swift
+++ b/CanvasPlusPlayground/Features/Courses/Models/Course.swift
@@ -65,7 +65,6 @@ final class Course: Cacheable {
     // MARK: Custom Properties
     // We cannot use `Color` directly because it needs to conform to `PersistentModel`
     var rgbColors: RGBColors?
-    // var isFavorite: Bool?
     var nickname: String?
     var isHidden: Bool?
 
@@ -224,9 +223,9 @@ final class Course: Cacheable {
         self.enrollmentRoleIds = other.enrollmentRoleIds
         self.enrollmentUserIds = other.enrollmentUserIds
         self.enrollmentStatesRaw = other.enrollmentStatesRaw
+        self.isFavorite = other.isFavorite
 
         // Note: These must NOT be merged.
-//        self.isFavorite = other.isFavorite
 //        self.rgbColors = other.rgbColors
 //        self.nickname = other.nickname
     }

--- a/CanvasPlusPlayground/Features/Navigation/CourseListCell.swift
+++ b/CanvasPlusPlayground/Features/Navigation/CourseListCell.swift
@@ -18,10 +18,6 @@ struct CourseListCell: View {
     @State private var showRenameTextField = false
     @State private var renameCourseFieldText: String = ""
 
-    private var wrappedCourseIsFavorite: Bool {
-        course.isFavorite
-    }
-
     private var wrappedCourseIsHidden: Bool {
         course.isHidden ?? false
     }
@@ -33,9 +29,6 @@ struct CourseListCell: View {
             .onAppear {
                 resolvedCourseColor = course.rgbColors?.color ?? .accentColor
             }
-            .swipeActions(edge: .leading) {
-                favoriteButton
-            }
             .swipeActions(edge: .trailing) {
                 hideCourseButton
             }
@@ -44,7 +37,6 @@ struct CourseListCell: View {
                     showColorPicker = true
                 }
 
-                favoriteButton
                 hideCourseButton
 
                 Button("Rename \(course.name ?? "")...", systemImage: "character.cursor.ibeam") {
@@ -96,18 +88,5 @@ struct CourseListCell: View {
         }
         .symbolVariant(wrappedCourseIsHidden ? .none : .slash)
         .tint(.gray)
-    }
-
-    private var favoriteButton: some View {
-        Button(
-            wrappedCourseIsFavorite ? "Unfavorite Course" : "Favorite Course",
-            systemImage: "star"
-        ) {
-            withAnimation {
-                course.isFavorite = !wrappedCourseIsFavorite
-            }
-        }
-        .symbolVariant(wrappedCourseIsFavorite ? .slash : .none)
-        .tint(.orange)
     }
 }

--- a/CanvasPlusPlayground/Features/Navigation/Sidebar.swift
+++ b/CanvasPlusPlayground/Features/Navigation/Sidebar.swift
@@ -24,19 +24,8 @@ struct Sidebar: View {
                 SidebarTiles()
             }
 
-            Section("Favorites") {
-                ForEach(courseManager.userFavCourses) { course in
-                    NavigationLink(
-                        value: NavigationPage.course(id: course.id)
-                    ) {
-                        CourseListCell(course: course)
-                    }
-                    .listItemTint(.fixed(course.rgbColors?.color ?? .accentColor))
-                }
-            }
-
             Section("My Courses") {
-                ForEach(courseManager.userOtherCourses) { course in
+                ForEach(courseManager.userCourses) { course in
                     NavigationLink(value: NavigationPage.course(id: course.id)) {
                         CourseListCell(course: course)
                     }

--- a/CanvasPlusPlayground/Features/Navigation/Sidebar.swift
+++ b/CanvasPlusPlayground/Features/Navigation/Sidebar.swift
@@ -33,9 +33,9 @@ struct Sidebar: View {
                 }
             }
 
-            if !courseManager.userHiddenCourses.isEmpty {
+            if !courseManager.hiddenCourses.isEmpty {
                 Section("Hidden", isExpanded: $isHiddenSectionExpanded) {
-                    ForEach(courseManager.userHiddenCourses) { course in
+                    ForEach(courseManager.hiddenCourses) { course in
                         NavigationLink(value: NavigationPage.course(id: course.id)) {
                             CourseListCell(course: course)
                         }

--- a/CanvasPlusPlayground/Features/People/PeopleCommonView.swift
+++ b/CanvasPlusPlayground/Features/People/PeopleCommonView.swift
@@ -66,7 +66,7 @@ struct PeopleCommonView: View {
         await PeopleManager
             .fetchAllClassesWith(
                 userID: id,
-                activeCourses: courseManager.displayedCourses
+                activeCourses: courseManager.userCourses
             ) {
             commonCourses.append($0)
             }


### PR DESCRIPTION
Fixes #259.

## Changes Made

- Removes Favorite Course Feature. The `isFavorite` attribute pulls and updates accordingly from Canvas.

## Screenshots (if applicable)

## Checklist
- [x] I have implemented all requirements for this PR and its accompanying issue.
- [x] I have verified my implementation across all edge cases.
- [x] I have ensured my changes compile on macOS & iOS.
- [x] I have resolved all SwiftLint warnings.
