### PR TITLE
Fix Grade Calculator Bug

### DIFF
--- a/CanvasPlusPlayground/Features/Grades/GradeCalculator/GradeCalculator.swift
+++ b/CanvasPlusPlayground/Features/Grades/GradeCalculator/GradeCalculator.swift
@@ -60,16 +60,20 @@ class GradeCalculator {
 
             // Drop the lowest assignments if specified
             if let dropLowest = rules?.dropLowest, dropLowest > 0 {
+                // Sort the lowest percentage scored assignments first
+                retValue.sort { ($0.percentage ?? 0.0) < ($1.percentage ?? 0.0) }
+
                 retValue = Array(
                     retValue
                         .dropFirst(min(dropLowest, retValue.count))
                 )
             }
 
-            retValue.sort { ($0.pointsEarned ?? 0.0) > ($1.pointsEarned ?? 0.0) }
-
             // Drop the highest assignments if specified
             if let dropHighest = rules?.dropHighest, dropHighest > 0 {
+                // Sort the highest percentage scored assignments first
+                retValue.sort { ($0.percentage ?? 0.0) > ($1.percentage ?? 0.0) }
+
                 retValue = Array(retValue.dropFirst(min(dropHighest, retValue.count)))
             }
 


### PR DESCRIPTION
Fixes --

## Changes Made

- The drop lowest assignment group rule was not being applied correctly in the grade calculator since the assignment weren't sorted before the calculation.

## Screenshots (if applicable)

## Checklist
- [x] I have implemented all requirements for this PR and its accompanying issue.
- [x] I have verified my implementation across all edge cases.
- [x] I have ensured my changes compile on macOS & iOS.
- [x] I have resolved all SwiftLint warnings.
