### PR TITLE
[Work towards IGC] Introduce Course Item Picker

### DIFF
--- a/CanvasPlusPlayground.xcodeproj/project.pbxproj
+++ b/CanvasPlusPlayground.xcodeproj/project.pbxproj
@@ -157,6 +157,10 @@
 		B7C0A3CD2D3023CA003E5A36 /* PinnedItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7C0A3CC2D3023CA003E5A36 /* PinnedItem.swift */; };
 		B7C0A3CF2D31F339003E5A36 /* PinnedItemCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7C0A3CE2D31F339003E5A36 /* PinnedItemCard.swift */; };
 		B7CC4D3C2D8DB87200254F55 /* URL+AppRootURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7CC4D3B2D8DB86E00254F55 /* URL+AppRootURL.swift */; };
+		B7CC4D3F2D8DFAEC00254F55 /* PickerService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7CC4D3E2D8DFAE900254F55 /* PickerService.swift */; };
+		B7CC4D412D8DFB7300254F55 /* PickableItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7CC4D402D8DFB7300254F55 /* PickableItem.swift */; };
+		B7CC4D432D8DFF0A00254F55 /* PickerServiceViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7CC4D422D8DFF0A00254F55 /* PickerServiceViewModifier.swift */; };
+		B7CC4D462D8DFFA500254F55 /* CourseItemPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7CC4D452D8DFFA000254F55 /* CourseItemPicker.swift */; };
 		B7D7512B2D3D5D8000F7B8B8 /* AllAnnouncementsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7D7512A2D3D5D7700F7B8B8 /* AllAnnouncementsView.swift */; };
 		B7D7512D2D3D652300F7B8B8 /* GetAnnouncementsBatchRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7D7512C2D3D652300F7B8B8 /* GetAnnouncementsBatchRequest.swift */; };
 		B7D7512F2D3D660B00F7B8B8 /* AllAnnouncementsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7D7512E2D3D660B00F7B8B8 /* AllAnnouncementsManager.swift */; };
@@ -326,6 +330,10 @@
 		B7C0A3CC2D3023CA003E5A36 /* PinnedItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinnedItem.swift; sourceTree = "<group>"; };
 		B7C0A3CE2D31F339003E5A36 /* PinnedItemCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinnedItemCard.swift; sourceTree = "<group>"; };
 		B7CC4D3B2D8DB86E00254F55 /* URL+AppRootURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+AppRootURL.swift"; sourceTree = "<group>"; };
+		B7CC4D3E2D8DFAE900254F55 /* PickerService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PickerService.swift; sourceTree = "<group>"; };
+		B7CC4D402D8DFB7300254F55 /* PickableItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PickableItem.swift; sourceTree = "<group>"; };
+		B7CC4D422D8DFF0A00254F55 /* PickerServiceViewModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PickerServiceViewModifier.swift; sourceTree = "<group>"; };
+		B7CC4D452D8DFFA000254F55 /* CourseItemPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseItemPicker.swift; sourceTree = "<group>"; };
 		B7D7512A2D3D5D7700F7B8B8 /* AllAnnouncementsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AllAnnouncementsView.swift; sourceTree = "<group>"; };
 		B7D7512C2D3D652300F7B8B8 /* GetAnnouncementsBatchRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetAnnouncementsBatchRequest.swift; sourceTree = "<group>"; };
 		B7D7512E2D3D660B00F7B8B8 /* AllAnnouncementsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AllAnnouncementsManager.swift; sourceTree = "<group>"; };
@@ -450,6 +458,7 @@
 				A373DC182D1A40EC00215019 /* Models */,
 				B76454F62C8DF61B002DF00E /* CourseView.swift */,
 				B76454FC2C8DF61B002DF00E /* CourseManager.swift */,
+				B7CC4D452D8DFFA000254F55 /* CourseItemPicker.swift */,
 			);
 			path = Courses;
 			sourceTree = "<group>";
@@ -485,6 +494,7 @@
 			isa = PBXGroup;
 			children = (
 				B7CC4D3B2D8DB86E00254F55 /* URL+AppRootURL.swift */,
+				B7CC4D442D8DFF1500254F55 /* PickerService */,
 				9B07E7112D779CA500359B69 /* Date+RelativeDates.swift */,
 				B7725D642D7387D300D64ED8 /* AccessoryBar.swift */,
 				A373DC0E2D19F71600215019 /* TypeSafeCodable.swift */,
@@ -807,6 +817,16 @@
 			path = "Pinned Items";
 			sourceTree = "<group>";
 		};
+		B7CC4D442D8DFF1500254F55 /* PickerService */ = {
+			isa = PBXGroup;
+			children = (
+				B7CC4D3E2D8DFAE900254F55 /* PickerService.swift */,
+				B7CC4D422D8DFF0A00254F55 /* PickerServiceViewModifier.swift */,
+				B7CC4D402D8DFB7300254F55 /* PickableItem.swift */,
+			);
+			path = PickerService;
+			sourceTree = "<group>";
+		};
 		B7D95DB52D0A8D6A002AD955 /* Settings */ = {
 			isa = PBXGroup;
 			children = (
@@ -980,6 +1000,7 @@
 				B7D95D772D07C3D3002AD955 /* ICSParser.swift in Sources */,
 				A3CF88D32D18E6BB000ACDF3 /* ParentKeyPath.swift in Sources */,
 				B7F9503B2D127AD0004BB470 /* ProfileAPI.swift in Sources */,
+				B7CC4D3F2D8DFAEC00254F55 /* PickerService.swift in Sources */,
 				A352AD1C2D3EF206007EE6FC /* User.swift in Sources */,
 				B76455012C8DF61B002DF00E /* StorageKeys.swift in Sources */,
 				A3FFD03A2CDEC2AC006BAB51 /* LookupCondition.swift in Sources */,
@@ -1012,6 +1033,7 @@
 				B5894F132D6EBD8C00E8F527 /* Page.swift in Sources */,
 				A373DC2B2D23EB3D00215019 /* Submission.swift in Sources */,
 				B7E59A122D20046B001836FE /* SidebarTile.swift in Sources */,
+				B7CC4D412D8DFB7300254F55 /* PickableItem.swift in Sources */,
 				9B92A4252C93856100C21CFC /* CourseAnnouncementManager.swift in Sources */,
 				A35191432D28ED48001E415F /* GetModuleItemsRequest.swift in Sources */,
 				B76455052C8DF61B002DF00E /* SetupView.swift in Sources */,
@@ -1025,6 +1047,7 @@
 				A3049B832D161432002F3166 /* GetAssignmentsRequest.swift in Sources */,
 				B7F9503D2D12ADAE004BB470 /* SubmissionAPI.swift in Sources */,
 				B7E59A102D2002A5001836FE /* Sidebar.swift in Sources */,
+				B7CC4D462D8DFFA500254F55 /* CourseItemPicker.swift in Sources */,
 				B7AD54F62CD41D7900FB09BB /* DeviceStat.swift in Sources */,
 				A3049B812D160F6B002F3166 /* GetAnnouncementsRequest.swift in Sources */,
 				A373DC332D2819F700215019 /* APIModuleItem.swift in Sources */,
@@ -1096,6 +1119,7 @@
 				A3D161512D178615004055FB /* GetUserProfileRequest.swift in Sources */,
 				A3D161492D169C23004055FB /* CacheableAPIRequest+Storage.swift in Sources */,
 				9B6663E32C9853BC0060990E /* HTMLTextView.swift in Sources */,
+				B7CC4D432D8DFF0A00254F55 /* PickerServiceViewModifier.swift in Sources */,
 				B73AE0BD2D4FB68B007094A8 /* Profile.swift in Sources */,
 				B7AD550C2CD4257B00FB09BB /* IntelligenceOnboardingView.swift in Sources */,
 				B7D751312D3D688C00F7B8B8 /* AnnouncementRow.swift in Sources */,

--- a/CanvasPlusPlayground/Common/Utilities/PickerService/PickableItem.swift
+++ b/CanvasPlusPlayground/Common/Utilities/PickerService/PickableItem.swift
@@ -1,0 +1,38 @@
+//
+//  PickableItem.swift
+//  CanvasPlusPlayground
+//
+//  Created by Rahul on 3/21/25.
+//
+
+import Foundation
+
+protocol PickableItem {
+    var contents: String { get }
+}
+
+extension DiscussionTopic: PickableItem {
+    var contents: String {
+        self.message ?? ""
+    }
+}
+
+extension File: PickableItem {
+    var contents: String {
+        CourseFileService.getContentsOfFile(at: self.localURL)
+    }
+
+    static var supportedPickableTypes: [String] {
+        #if os(macOS)
+        ["doc", "docx", "pdf", "txt", "html"]
+        #else
+        ["pdf", "txt", "html"]
+        #endif
+    }
+}
+
+extension Page: PickableItem {
+    var contents: String {
+        self.body ?? ""
+    }
+}

--- a/CanvasPlusPlayground/Common/Utilities/PickerService/PickableItem.swift
+++ b/CanvasPlusPlayground/Common/Utilities/PickerService/PickableItem.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-protocol PickableItem {
+protocol PickableItem: Equatable {
     var contents: String { get }
 }
 

--- a/CanvasPlusPlayground/Common/Utilities/PickerService/PickableItem.swift
+++ b/CanvasPlusPlayground/Common/Utilities/PickerService/PickableItem.swift
@@ -7,9 +7,11 @@
 
 import Foundation
 
-protocol PickableItem: Equatable {
+protocol PickableItem {
     var contents: String { get }
 }
+
+extension PickableItem where Self: Equatable { }
 
 extension DiscussionTopic: PickableItem {
     var contents: String {

--- a/CanvasPlusPlayground/Common/Utilities/PickerService/PickerService.swift
+++ b/CanvasPlusPlayground/Common/Utilities/PickerService/PickerService.swift
@@ -23,7 +23,7 @@ class PickerService {
         }
     }
 
-    var pickedItem: PickableItem?
+    var pickedItem: (any PickableItem)?
 
     var supportedPickerViews: [NavigationModel.CoursePage] = [
         .announcements,
@@ -32,7 +32,7 @@ class PickerService {
         // TODO: Add more supported picker pages.
     ]
 
-    func validatePickedItem() throws -> Bool {
+    func validatePickedItem() throws {
         guard let pickedItem else { throw PickerServiceError.emptySelection }
 
         if let file = pickedItem as? File, let ext = file.localURL?.pathExtension {
@@ -40,7 +40,5 @@ class PickerService {
                 throw PickerServiceError.invalidSelection
             }
         }
-
-        return true
     }
 }

--- a/CanvasPlusPlayground/Common/Utilities/PickerService/PickerService.swift
+++ b/CanvasPlusPlayground/Common/Utilities/PickerService/PickerService.swift
@@ -1,0 +1,46 @@
+//
+//  PickerService.swift
+//  CanvasPlusPlayground
+//
+//  Created by Rahul on 3/21/25.
+//
+
+import SwiftUI
+
+@Observable
+class PickerService {
+    enum PickerServiceError: LocalizedError {
+        case emptySelection
+        case invalidSelection
+
+        var errorDescription: String? {
+            switch self {
+            case .emptySelection:
+                return "An item has not been selected."
+            case .invalidSelection:
+                return "This file type is not supported."
+            }
+        }
+    }
+
+    var pickedItem: PickableItem?
+
+    var supportedPickerViews: [NavigationModel.CoursePage] = [
+        .announcements,
+        .files,
+        .pages
+        // TODO: Add more supported picker pages.
+    ]
+
+    func validatePickedItem() throws -> Bool {
+        guard let pickedItem else { throw PickerServiceError.emptySelection }
+
+        if let file = pickedItem as? File, let ext = file.localURL?.pathExtension {
+            if !File.supportedPickableTypes.contains(ext) {
+                throw PickerServiceError.invalidSelection
+            }
+        }
+
+        return true
+    }
+}

--- a/CanvasPlusPlayground/Common/Utilities/PickerService/PickerServiceViewModifier.swift
+++ b/CanvasPlusPlayground/Common/Utilities/PickerService/PickerServiceViewModifier.swift
@@ -7,21 +7,21 @@
 
 import SwiftUI
 
-private struct PickerServiceViewModifier: ViewModifier {
+private struct PickerServiceViewModifier<T: PickableItem & Equatable>: ViewModifier {
     @Environment(PickerService.self) private var pickerService: PickerService?
 
-    var item: (any PickableItem)?
+    var item: T?
 
     func body(content: Content) -> some View {
         content
-            .onChange(of: item?.contents) { _, _ in
+            .onChange(of: item) { _, _ in
                 pickerService?.pickedItem = item
             }
     }
 }
 
 extension View {
-    func pickedItem(_ item: (any PickableItem)?) -> some View {
+    func pickedItem<T: PickableItem & Equatable>(_ item: T?) -> some View {
         modifier(PickerServiceViewModifier(item: item))
     }
 }

--- a/CanvasPlusPlayground/Common/Utilities/PickerService/PickerServiceViewModifier.swift
+++ b/CanvasPlusPlayground/Common/Utilities/PickerService/PickerServiceViewModifier.swift
@@ -1,0 +1,27 @@
+//
+//  PickerServiceViewModifier.swift
+//  CanvasPlusPlayground
+//
+//  Created by Rahul on 3/21/25.
+//
+
+import SwiftUI
+
+private struct PickerServiceViewModifier: ViewModifier {
+    @Environment(PickerService.self) private var pickerService: PickerService?
+
+    var item: PickableItem?
+
+    func body(content: Content) -> some View {
+        content
+            .onChange(of: item?.contents) { _, _ in
+                pickerService?.pickedItem = item
+            }
+    }
+}
+
+extension View {
+    func pickedItem(_ item: PickableItem?) -> some View {
+        modifier(PickerServiceViewModifier(item: item))
+    }
+}

--- a/CanvasPlusPlayground/Common/Utilities/PickerService/PickerServiceViewModifier.swift
+++ b/CanvasPlusPlayground/Common/Utilities/PickerService/PickerServiceViewModifier.swift
@@ -10,7 +10,7 @@ import SwiftUI
 private struct PickerServiceViewModifier: ViewModifier {
     @Environment(PickerService.self) private var pickerService: PickerService?
 
-    var item: PickableItem?
+    var item: (any PickableItem)?
 
     func body(content: Content) -> some View {
         content
@@ -21,7 +21,7 @@ private struct PickerServiceViewModifier: ViewModifier {
 }
 
 extension View {
-    func pickedItem(_ item: PickableItem?) -> some View {
+    func pickedItem(_ item: (any PickableItem)?) -> some View {
         modifier(PickerServiceViewModifier(item: item))
     }
 }

--- a/CanvasPlusPlayground/Features/Announcements/CourseAnnouncementsView.swift
+++ b/CanvasPlusPlayground/Features/Announcements/CourseAnnouncementsView.swift
@@ -46,6 +46,7 @@ struct CourseAnnouncementsView: View {
         .navigationDestination(item: $selectedAnnouncement) { announcement in
             CourseAnnouncementDetailView(announcement: announcement)
         }
+        .pickedItem(selectedAnnouncement)
     }
 
     private func loadAnnouncements() async {

--- a/CanvasPlusPlayground/Features/Courses/CourseItemPicker.swift
+++ b/CanvasPlusPlayground/Features/Courses/CourseItemPicker.swift
@@ -1,0 +1,106 @@
+//
+//  CourseItemPicker.swift
+//  CanvasPlusPlayground
+//
+//  Created by Rahul on 3/21/25.
+//
+
+import SwiftUI
+
+struct CourseItemPicker: View {
+    @Environment(\.dismiss) private var dismiss
+
+    let course: Course
+    @Binding var selectedItem: (any PickableItem)?
+
+    @State private var service = PickerService()
+    @State private var navigationModel = NavigationModel()
+
+    @State private var error: PickerService.PickerServiceError?
+
+    private var showErrorAlert: Binding<Bool> {
+        Binding<Bool>(
+            get: { error != nil },
+            set: {
+                if !$0 {
+                    error = nil
+                }
+            }
+        )
+    }
+
+    var body: some View {
+        NavigationStack {
+            mainBody
+        }
+        .onDisappear {
+            LoggerService.main.debug(
+                """
+                Picked Item: \(String(describing: service.pickedItem))
+                Contents: \(String(describing: service.pickedItem?.contents))
+                """
+            )
+        }
+        .onChange(of: service.pickedItem?.contents) { _, _ in
+            selectedItem = service.pickedItem
+        }
+        .environment(service)
+        .environment(navigationModel)
+        .alert(isPresented: showErrorAlert, error: error) { _ in
+            Button("OK") { showErrorAlert.wrappedValue = false }
+        } message: { _ in
+            Text("Cannot select item.")
+        }
+
+        #if os(macOS)
+        .frame(width: 400, height: 500)
+        #else
+        .safeAreaInset(edge: .bottom) {
+            VStack(spacing: 0) {
+                Divider()
+
+                HStack {
+                    cancelButton
+                    Spacer()
+                    confirmButton
+                }
+                .padding()
+                .background(.thinMaterial)
+                .bold()
+            }
+        }
+        #endif
+    }
+
+    private var mainBody: some View {
+        CourseView(course: course)
+            #if os(macOS)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    cancelButton
+                }
+
+                ToolbarItem(placement: .confirmationAction) {
+                    confirmButton
+                }
+            }
+            #endif
+    }
+
+    private var cancelButton: some View {
+        Button("Cancel") { dismiss() }
+    }
+
+    private var confirmButton: some View {
+        Button("Choose") {
+            do {
+                if try service.validatePickedItem() {
+                    dismiss()
+                }
+            } catch {
+                self.error = error as? PickerService.PickerServiceError
+            }
+        }
+        .disabled(service.pickedItem == nil)
+    }
+}

--- a/CanvasPlusPlayground/Features/Courses/CourseItemPicker.swift
+++ b/CanvasPlusPlayground/Features/Courses/CourseItemPicker.swift
@@ -94,9 +94,8 @@ struct CourseItemPicker: View {
     private var confirmButton: some View {
         Button("Choose") {
             do {
-                if try service.validatePickedItem() {
-                    dismiss()
-                }
+                try service.validatePickedItem()
+                dismiss()
             } catch {
                 self.error = error as? PickerService.PickerServiceError
             }

--- a/CanvasPlusPlayground/Features/Courses/CourseView.swift
+++ b/CanvasPlusPlayground/Features/Courses/CourseView.swift
@@ -8,13 +8,18 @@
 import SwiftUI
 
 struct CourseView: View {
+    @Environment(PickerService.self) private var pickerService: PickerService?
     @Environment(NavigationModel.self) private var navigationModel
     let course: Course
+
+    private var coursePages: [NavigationModel.CoursePage] {
+        pickerService?.supportedPickerViews ?? NavigationModel.CoursePage.allCases
+    }
 
     var body: some View {
         @Bindable var navigationModel = navigationModel
 
-        List(NavigationModel.CoursePage.allCases, id: \.self, selection: $navigationModel.selectedCoursePage) { page in
+        List(coursePages, id: \.self, selection: $navigationModel.selectedCoursePage) { page in
             NavigationLink(value: page) {
                 Label(page.title, systemImage: page.systemImageIcon)
             }

--- a/CanvasPlusPlayground/Features/Files/FileViewer.swift
+++ b/CanvasPlusPlayground/Features/Files/FileViewer.swift
@@ -23,7 +23,6 @@ struct FileViewer: View {
             if let url {
                 QuickLookPreview(url: url) { dismiss() }
                     #if os(iOS)
-                    .navigationBarBackButtonHidden()
                     .ignoresSafeArea()
                     #else
                     .toolbar {
@@ -53,6 +52,9 @@ struct FileViewer: View {
         .task {
             await loadContents()
         }
+        #if os(iOS)
+        .navigationBarBackButtonHidden()
+        #endif
     }
 
     private func loadContents() async {

--- a/CanvasPlusPlayground/Features/Files/FoldersPageView.swift
+++ b/CanvasPlusPlayground/Features/Files/FoldersPageView.swift
@@ -21,7 +21,7 @@ struct FoldersPageView: View {
             }
         }
 
-        var pickedValue: (any PickableItem)? {
+        var pickedValue: File? {
             if case .file(let file) = self {
                 return file
             } else {

--- a/CanvasPlusPlayground/Features/Files/FoldersPageView.swift
+++ b/CanvasPlusPlayground/Features/Files/FoldersPageView.swift
@@ -21,7 +21,7 @@ struct FoldersPageView: View {
             }
         }
 
-        var pickedValue: PickableItem? {
+        var pickedValue: (any PickableItem)? {
             if case .file(let file) = self {
                 return file
             } else {

--- a/CanvasPlusPlayground/Features/Navigation/NavigationModel.swift
+++ b/CanvasPlusPlayground/Features/Navigation/NavigationModel.swift
@@ -95,6 +95,7 @@ class NavigationModel {
         }
     }
     var selectedCoursePage: CoursePage?
+    var selectedCourseForItemPicker: Course?
     var showInstallIntelligenceSheet = false
     var showAuthorizationSheet = false
     var showProfileSheet = false

--- a/CanvasPlusPlayground/Features/Pages/PagesListView.swift
+++ b/CanvasPlusPlayground/Features/Pages/PagesListView.swift
@@ -11,15 +11,15 @@ struct PagesListView: View {
     @State private var pagesManager: PagesManager
     @State private var isLoadingPages: Bool = true
 
+    @State private var selectedPage: Page?
+
     init(courseId: String) {
         _pagesManager = State(initialValue: PagesManager(courseID: courseId))
     }
 
     var body: some View {
-        List(pagesManager.pages, id: \.id) { page in
-            NavigationLink {
-                PageView(page: page)
-            } label: {
+        List(pagesManager.pages, id: \.id, selection: $selectedPage) { page in
+            NavigationLink(value: page) {
                 Text(page.title ?? "Untitled")
             }
         }
@@ -41,6 +41,10 @@ struct PagesListView: View {
             isVisible: isLoadingPages
         )
         .navigationTitle("Pages")
+        .navigationDestination(item: $selectedPage) { page in
+            PageView(page: page)
+        }
+        .pickedItem(selectedPage)
     }
 
     private func loadPages() async {

--- a/CanvasPlusPlayground/Features/Settings/SettingsView.swift
+++ b/CanvasPlusPlayground/Features/Settings/SettingsView.swift
@@ -10,7 +10,11 @@ import SwiftUI
 struct SettingsView: View {
     #if DEBUG
     @Environment(PinnedItemsManager.self) private var pinnedItemManager
+    @Environment(CourseManager.self) private var courseManager
+
+    @State private var selectedItem: (any PickableItem)?
     #endif
+
     @Environment(NavigationModel.self) private var navigationModel
     @EnvironmentObject private var llmEvaluator: LLMEvaluator
     @EnvironmentObject private var intelligenceManager: IntelligenceManager
@@ -24,6 +28,11 @@ struct SettingsView: View {
         NavigationStack {
             mainBody
         }
+        #if DEBUG
+        .sheet(item: $navigationModel.selectedCourseForItemPicker) {
+            CourseItemPicker(course: $0, selectedItem: $selectedItem)
+        }
+        #endif
         .sheet(isPresented: $showChangeAccessToken) {
             NavigationStack {
                 SetupView()
@@ -98,9 +107,16 @@ struct SettingsView: View {
     }
 
     #if DEBUG
+    @ViewBuilder
     private var debugSettings: some View {
+        @Bindable var navigationModel = navigationModel
+
         Section {
             Group {
+                Button("View Item Picker", systemImage: "filemenu.and.selection") {
+                    navigationModel.selectedCourseForItemPicker = courseManager.userCourses.first
+                }
+
                 Button("Clear Pinned Items", systemImage: "trash") {
                     pinnedItemManager.clearAllPinnedItems()
                 }


### PR DESCRIPTION
Work towards IGC:

In IGC, we would like the user to be able to navigate the course materials, and pick the syllabus document manually, which will then be parsed for the grade weights. As a first step for this, we introduce an item picker which allows the user to pick either an Announcement, File, or Page from a course. The contents of the picked item is returned.

Supported File types are currently doc/docx (macOS only), pdf, html, txt.

## Implementation Outline

- Introduce a `PickerService` which is injected into the view hierarchy only when necessary (in `CourseItemPicker`).
- A view modifier (`pickedItem(:_)`) is used to update the service's picked item when a list item is selected.
- A binding is provided to `CourseItemPicker` whose contents can then be examined afterwards as needed.

## Screenshots (if applicable)

<img width="512" alt="image" src="https://github.com/user-attachments/assets/f1bc0569-222f-4000-87c2-207351874159" />
<img width="512" alt="Screenshot 2025-03-21 at 7 20 23 PM" src="https://github.com/user-attachments/assets/5de00ae1-9191-43ef-a8e9-238df8080604" />
<img width="512" alt="Screenshot 2025-03-21 at 7 20 06 PM" src="https://github.com/user-attachments/assets/d9103b2c-fc82-4202-aa27-f34cafe44ab7" />

## Checklist
- [x] I have implemented all requirements for this PR and its accompanying issue.
- [x] I have verified my implementation across all edge cases.
- [x] I have ensured my changes compile on macOS & iOS.
- [x] I have resolved all SwiftLint warnings.
