### PR TITLE
display tabs based on fetch tabs API

### DIFF
--- a/CanvasPlusPlayground/Features/Courses/CourseView.swift
+++ b/CanvasPlusPlayground/Features/Courses/CourseView.swift
@@ -10,10 +10,32 @@ import SwiftUI
 struct CourseView: View {
     @Environment(PickerService.self) private var pickerService: PickerService?
     @Environment(NavigationModel.self) private var navigationModel
+    @State private var tabsManager: CourseTabsManager
     let course: Course
 
+    init(course: Course) {
+        self.course = course
+        self.tabsManager = CourseTabsManager(course: course)
+    }
+
     private var coursePages: [NavigationModel.CoursePage] {
-        pickerService?.supportedPickerViews ?? NavigationModel.CoursePage.allCases
+        guard !tabsManager.tabs.isEmpty else {
+                return []
+            }
+
+        let availableTabs = Set<NavigationModel.CoursePage>(
+            tabsManager.tabs.compactMap { tab in
+                guard let label = tab.label else { return nil }
+                return NavigationModel.CoursePage(rawValue: label.lowercased())
+            }
+        )
+
+        // add to requiredTabs to always include the specific tab
+        let requiredTabs: Set<NavigationModel.CoursePage> = [
+            .tabs
+        ]
+
+        return NavigationModel.CoursePage.allCases.filter { availableTabs.contains($0) || requiredTabs.contains($0) }
     }
 
     var body: some View {
@@ -27,6 +49,15 @@ struct CourseView: View {
         }
         .onAppear {
             navigationModel.selectedCoursePage = nil
+            Task {
+                await tabsManager.fetchTabs()
+            }
+        }
+        .onChange(of: course) { _, newCourse in
+            tabsManager = CourseTabsManager(course: newCourse)
+            Task {
+                await tabsManager.fetchTabs()
+            }
         }
         #if os(iOS)
         .listStyle(.insetGrouped)

--- a/CanvasPlusPlayground/Features/Courses/CourseView.swift
+++ b/CanvasPlusPlayground/Features/Courses/CourseView.swift
@@ -15,7 +15,7 @@ struct CourseView: View {
 
     init(course: Course) {
         self.course = course
-        self.tabsManager = CourseTabsManager(course: course)
+        self._tabsManager = State(wrappedValue: CourseTabsManager(course: course))
     }
 
     private var coursePages: [NavigationModel.CoursePage] {

--- a/CanvasPlusPlayground/Features/Courses/CourseView.swift
+++ b/CanvasPlusPlayground/Features/Courses/CourseView.swift
@@ -30,12 +30,9 @@ struct CourseView: View {
             }
         )
 
-        // add to requiredTabs to always include the specific tab
-        let requiredTabs: Set<NavigationModel.CoursePage> = [
-            .tabs
-        ]
-
-        return NavigationModel.CoursePage.allCases.filter { availableTabs.contains($0) || requiredTabs.contains($0) }
+        return NavigationModel.CoursePage.allCases.filter {
+            availableTabs.contains($0) || NavigationModel.CoursePage.requiredTabs.contains($0)
+        }
     }
 
     var body: some View {

--- a/CanvasPlusPlayground/Features/Navigation/NavigationModel.swift
+++ b/CanvasPlusPlayground/Features/Navigation/NavigationModel.swift
@@ -63,6 +63,10 @@ class NavigationModel {
             rawValue.capitalized
         }
 
+        static let requiredTabs: Set<CoursePage> = [
+            .tabs, .people
+        ]
+
         var systemImageIcon: String {
             switch self {
             case .files:


### PR DESCRIPTION
Fixes #262 

Currently, we displayed all types of tabs listed in the enum `CoursePages`. But some courses don't display them, so we should filter out the ones that the instruction team has left private.

## Changes Made

- In `CourseView`, we now call `fetchTabs` with an instance of `CourseTabsManager`
- Due to Swift optimization, when switching pages, the `CourseView` maintains the same view. To ensure that the tabs displayed are refreshed each time we change courses, we used an `onChange` function based on the `course` passed in. 
- As we have a custom tab called "tab", this is always displayed to allow users to see all the pages we are not displaying. If we have such tabs again in the future, simply adding to the requiredTabs array will ensure that tab is always displayed.

## Screenshots (if applicable)
<img width="564" alt="Screenshot 2025-03-27 at 1 49 22 PM" src="https://github.com/user-attachments/assets/e503bd34-2faf-416a-a7cc-a358931da717" />
<img width="540" alt="Screenshot 2025-03-27 at 1 49 36 PM" src="https://github.com/user-attachments/assets/7779ba71-5a80-4453-b56a-ed9c74f1db21" />

## Checklist
- [x] I have implemented all requirements for this PR and its accompanying issue.
- [x] I have verified my implementation across all edge cases.
- [x] I have ensured my changes compile on macOS & iOS.
- [x] I have resolved all SwiftLint warnings.
