### PR TITLE
Fix Intelligence following macOS Sandbox addition

### DIFF
--- a/CanvasPlusPlayground.xcodeproj/project.pbxproj
+++ b/CanvasPlusPlayground.xcodeproj/project.pbxproj
@@ -1342,6 +1342,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
 				CODE_SIGN_ENTITLEMENTS = CanvasPlusPlayground/CanvasPlusPlayground.entitlements;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"CanvasPlusPlayground/Preview Content\"";
@@ -1382,6 +1383,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
 				CODE_SIGN_ENTITLEMENTS = CanvasPlusPlayground/CanvasPlusPlayground.entitlements;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"CanvasPlusPlayground/Preview Content\"";

--- a/CanvasPlusPlayground/CanvasPlusPlayground.entitlements
+++ b/CanvasPlusPlayground/CanvasPlusPlayground.entitlements
@@ -2,7 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.developer.kernel.increased-memory-limit</key>
+	<true/>
 	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.files.user-selected.read-only</key>
 	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>

--- a/CanvasPlusPlayground/Intelligence/LLMEvaluator.swift
+++ b/CanvasPlusPlayground/Intelligence/LLMEvaluator.swift
@@ -21,11 +21,6 @@ class LLMEvaluator: ObservableObject {
         }
     }
 
-    private static var llmDownloadBase: URL? {
-        URL.appRootURL?
-            .appending(component: "intelligence")
-    }
-
     var running = false
     var output = ""
     var modelInfo = ""
@@ -70,7 +65,6 @@ class LLMEvaluator: ObservableObject {
             MLX.GPU.set(cacheLimit: 20 * 1024 * 1024)
 
             let modelContainer = try await MLXLLM.loadModelContainer(
-                hub: .init(downloadBase: Self.llmDownloadBase),
                 configuration: model
             ) { [modelConfiguration] progress in
                 Task { @MainActor in


### PR DESCRIPTION
Fixes --

Intelligence features did not work following the addition of the sandbox. I revert to using the default directory for the model's download base, which is the sandboxed Documents directory.

## Changes Made

- Use the default directory (documents within sandbox) to save models
- Added permissions for reading user-selected files, which is needed for assignment submissions

## Screenshots (if applicable)

## Checklist
- [x] I have implemented all requirements for this PR and its accompanying issue.
- [x] I have verified my implementation across all edge cases.
- [x] I have ensured my changes compile on macOS & iOS.
- [x] I have resolved all SwiftLint warnings.
