### PR TITLE
Tabs Fixes

### DIFF
--- a/CanvasPlusPlayground/Features/Tabs/CourseTabsManager.swift
+++ b/CanvasPlusPlayground/Features/Tabs/CourseTabsManager.swift
@@ -9,21 +9,18 @@ import Foundation
 
 @Observable
 class CourseTabsManager {
-    let course: Course
     var tabs = [TabAPI]()
 
     var tabLabels: [String] {
         tabs.map(\.label).compactMap { $0 }
     }
 
-    init(course: Course) {
-        self.course = course
-    }
-
-    func fetchTabs() async {
+    func fetchTabs(course: Course) async {
         let courseId = course.id
+
         guard let (data, _) = try? await CanvasService.shared.fetchResponse(CanvasRequest.getTabs(courseId: courseId)) else {
             LoggerService.main.error("Unable to fetch tabs.")
+            self.tabs = []
             return
         }
 

--- a/CanvasPlusPlayground/Features/Tabs/CourseTabsView.swift
+++ b/CanvasPlusPlayground/Features/Tabs/CourseTabsView.swift
@@ -9,16 +9,16 @@ import SwiftUI
 import WebKit
 
 struct CourseTabsView: View {
+    @Environment(CourseTabsManager.self) private var tabsManager
+
     let course: Course
     let baseURL: String
-    @State private var tabsManager: CourseTabsManager
 
     @State private var selectedURL: URL?
     @State private var showWebView = false
 
     init(course: Course) {
         self.course = course
-        self.tabsManager = CourseTabsManager(course: course)
         self.baseURL = "https://gatech.instructure.com/courses/\(String(course.id))"
     }
 
@@ -36,7 +36,7 @@ struct CourseTabsView: View {
         }
         .navigationTitle("Tabs")
         .task {
-            await tabsManager.fetchTabs()
+            await tabsManager.fetchTabs(course: course)
         }
         .sheet(isPresented: $showWebView) {
             NavigationStack {


### PR DESCRIPTION
Fixes --

The changes in #288 reverted changes that require the PickerService (#270) to work correctly. I've added some logic back, and done some refactoring to ensure we don't create a `CourseTabsManager` every time we open the view.

## Changes Made

- Use `task(id:)` to call the function again when course changes instead of `onChange` and `onAppear`.
- Pass `course` into `fetchTabs` as a parameter
- Pass `CourseTabsManager` through the environment so it can be used in `CourseTabsView`
- Disable the `CourseView` when tabs are fetching, which is important when switching tabs.

## Screenshots (if applicable)

## Checklist
- [x] I have implemented all requirements for this PR and its accompanying issue.
- [x] I have verified my implementation across all edge cases.
- [x] I have ensured my changes compile on macOS & iOS.
- [x] I have resolved all SwiftLint warnings.
