### PR TITLE
Add To-Do Feature

### DIFF
--- a/CanvasPlusPlayground.xcodeproj/project.pbxproj
+++ b/CanvasPlusPlayground.xcodeproj/project.pbxproj
@@ -1207,7 +1207,6 @@
 				B7C0A3C52D2F4C19003E5A36 /* GetAssignmentRequest.swift in Sources */,
 				A37AB4A92D9867D600610639 /* UpdateGroupMembershipRequest.swift in Sources */,
 				B7CC4D6A2D91AF8200254F55 /* ToDoItemAPI.swift in Sources */,
-				A3FFD03E2CE0065A006BAB51 /* NetworkError.swift in Sources */,
 				B7E59A142D2004A4001836FE /* CourseListCell.swift in Sources */,
 				B53D95A22CA0A22A00647EE9 /* PeopleView.swift in Sources */,
 				A373DC312D28176100215019 /* APIModule.swift in Sources */,

--- a/CanvasPlusPlayground.xcodeproj/project.pbxproj
+++ b/CanvasPlusPlayground.xcodeproj/project.pbxproj
@@ -203,6 +203,7 @@
 		B7E0735E2D986B2400A7E82F /* GetUserTodoItemCountRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7E0735D2D986B1F00A7E82F /* GetUserTodoItemCountRequest.swift */; };
 		B7E073602D986D9800A7E82F /* ToDoItemCountAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7E0735F2D986D9800A7E82F /* ToDoItemCountAPI.swift */; };
 		B7E073622D986DD300A7E82F /* ToDoItemCount.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7E073612D986DCF00A7E82F /* ToDoItemCount.swift */; };
+		B7E073642D9872AE00A7E82F /* IgnoreToDoItemRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7E073632D9872AE00A7E82F /* IgnoreToDoItemRequest.swift */; };
 		B7E59A102D2002A5001836FE /* Sidebar.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7E59A0F2D2002A3001836FE /* Sidebar.swift */; };
 		B7E59A122D20046B001836FE /* SidebarTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7E59A112D20046B001836FE /* SidebarTile.swift */; };
 		B7E59A142D2004A4001836FE /* CourseListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7E59A132D2004A4001836FE /* CourseListCell.swift */; };
@@ -413,6 +414,7 @@
 		B7E0735D2D986B1F00A7E82F /* GetUserTodoItemCountRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetUserTodoItemCountRequest.swift; sourceTree = "<group>"; };
 		B7E0735F2D986D9800A7E82F /* ToDoItemCountAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToDoItemCountAPI.swift; sourceTree = "<group>"; };
 		B7E073612D986DCF00A7E82F /* ToDoItemCount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToDoItemCount.swift; sourceTree = "<group>"; };
+		B7E073632D9872AE00A7E82F /* IgnoreToDoItemRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IgnoreToDoItemRequest.swift; sourceTree = "<group>"; };
 		B7E59A0F2D2002A3001836FE /* Sidebar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar.swift; sourceTree = "<group>"; };
 		B7E59A112D20046B001836FE /* SidebarTile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarTile.swift; sourceTree = "<group>"; };
 		B7E59A132D2004A4001836FE /* CourseListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseListCell.swift; sourceTree = "<group>"; };
@@ -461,6 +463,7 @@
 			children = (
 				B7CC4D662D91AF3B00254F55 /* GetUserTodoItemsRequest.swift */,
 				B7E0735D2D986B1F00A7E82F /* GetUserTodoItemCountRequest.swift */,
+				B7E073632D9872AE00A7E82F /* IgnoreToDoItemRequest.swift */,
 				B7A12F3E2D69440F00EDFA0A /* GetAssignmentGroupsRequest.swift */,
 				B7D7512C2D3D652300F7B8B8 /* GetAnnouncementsBatchRequest.swift */,
 				A3049B762D15DC36002F3166 /* GetCourseRequest.swift */,
@@ -1274,6 +1277,7 @@
 				A3E7F3892C954E0500DC4300 /* CanvasRequest.swift in Sources */,
 				A352AD1A2D3EF1C1007EE6FC /* GetCourseUsersRequest.swift in Sources */,
 				B7460A942D6BFB1A0069CF5B /* GradeCalculator.swift in Sources */,
+				B7E073642D9872AE00A7E82F /* IgnoreToDoItemRequest.swift in Sources */,
 				B77FD0072D5309340049AA5E /* ProfilePicture.swift in Sources */,
 				A35191412D283589001E415F /* ModulesViewModel.swift in Sources */,
 				A3E7F3912C99317100DC4300 /* CourseTabsManager.swift in Sources */,

--- a/CanvasPlusPlayground.xcodeproj/project.pbxproj
+++ b/CanvasPlusPlayground.xcodeproj/project.pbxproj
@@ -200,6 +200,9 @@
 		B7D751312D3D688C00F7B8B8 /* AnnouncementRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7D751302D3D688C00F7B8B8 /* AnnouncementRow.swift */; };
 		B7D95D772D07C3D3002AD955 /* ICSParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7D95D762D07C3D3002AD955 /* ICSParser.swift */; };
 		B7D95DB72D0A8D78002AD955 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7D95DB62D0A8D75002AD955 /* SettingsView.swift */; };
+		B7E0735E2D986B2400A7E82F /* GetUserTodoItemCountRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7E0735D2D986B1F00A7E82F /* GetUserTodoItemCountRequest.swift */; };
+		B7E073602D986D9800A7E82F /* ToDoItemCountAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7E0735F2D986D9800A7E82F /* ToDoItemCountAPI.swift */; };
+		B7E073622D986DD300A7E82F /* ToDoItemCount.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7E073612D986DCF00A7E82F /* ToDoItemCount.swift */; };
 		B7E59A102D2002A5001836FE /* Sidebar.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7E59A0F2D2002A3001836FE /* Sidebar.swift */; };
 		B7E59A122D20046B001836FE /* SidebarTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7E59A112D20046B001836FE /* SidebarTile.swift */; };
 		B7E59A142D2004A4001836FE /* CourseListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7E59A132D2004A4001836FE /* CourseListCell.swift */; };
@@ -407,6 +410,9 @@
 		B7D751302D3D688C00F7B8B8 /* AnnouncementRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnouncementRow.swift; sourceTree = "<group>"; };
 		B7D95D762D07C3D3002AD955 /* ICSParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ICSParser.swift; sourceTree = "<group>"; };
 		B7D95DB62D0A8D75002AD955 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
+		B7E0735D2D986B1F00A7E82F /* GetUserTodoItemCountRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetUserTodoItemCountRequest.swift; sourceTree = "<group>"; };
+		B7E0735F2D986D9800A7E82F /* ToDoItemCountAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToDoItemCountAPI.swift; sourceTree = "<group>"; };
+		B7E073612D986DCF00A7E82F /* ToDoItemCount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToDoItemCount.swift; sourceTree = "<group>"; };
 		B7E59A0F2D2002A3001836FE /* Sidebar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar.swift; sourceTree = "<group>"; };
 		B7E59A112D20046B001836FE /* SidebarTile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarTile.swift; sourceTree = "<group>"; };
 		B7E59A132D2004A4001836FE /* CourseListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseListCell.swift; sourceTree = "<group>"; };
@@ -454,6 +460,7 @@
 			isa = PBXGroup;
 			children = (
 				B7CC4D662D91AF3B00254F55 /* GetUserTodoItemsRequest.swift */,
+				B7E0735D2D986B1F00A7E82F /* GetUserTodoItemCountRequest.swift */,
 				B7A12F3E2D69440F00EDFA0A /* GetAssignmentGroupsRequest.swift */,
 				B7D7512C2D3D652300F7B8B8 /* GetAnnouncementsBatchRequest.swift */,
 				A3049B762D15DC36002F3166 /* GetCourseRequest.swift */,
@@ -986,6 +993,8 @@
 		B7CC4D6F2D91C9C600254F55 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				B7E073612D986DCF00A7E82F /* ToDoItemCount.swift */,
+				B7E0735F2D986D9800A7E82F /* ToDoItemCountAPI.swift */,
 				B7CC4D692D91AF7500254F55 /* ToDoItemAPI.swift */,
 				B7CC4D6D2D91B26F00254F55 /* ToDoItem.swift */,
 			);
@@ -1275,6 +1284,7 @@
 				B76455062C8DF61B002DF00E /* CanvasPlusPlaygroundApp.swift in Sources */,
 				B7F950342D11A00F004BB470 /* StatusToolbarItem.swift in Sources */,
 				A37AB4AD2D98B05E00610639 /* CanvasGroup+Memberships.swift in Sources */,
+				B7E073602D986D9800A7E82F /* ToDoItemCountAPI.swift in Sources */,
 				A301EE0F2D612EA800D71139 /* DiscussionTopic.swift in Sources */,
 				9B07E7122D779CAB00359B69 /* Date+RelativeDates.swift in Sources */,
 				9B69FA4B2CC2CC7F006101F3 /* AggregatedAssignmentsView.swift in Sources */,
@@ -1290,6 +1300,7 @@
 				A3CF88DF2D1921B5000ACDF3 /* FileAPI.swift in Sources */,
 				B7CC4D3C2D8DB87200254F55 /* URL+AppRootURL.swift in Sources */,
 				B7CC4D6E2D91B27200254F55 /* ToDoItem.swift in Sources */,
+				B7E0735E2D986B2400A7E82F /* GetUserTodoItemCountRequest.swift in Sources */,
 				A3CF88DD2D1921A7000ACDF3 /* QuizAPI.swift in Sources */,
 				A3049B532D0E5241002F3166 /* Quiz.swift in Sources */,
 				A3049B872D16146D002F3166 /* GetQuizzesRequest.swift in Sources */,
@@ -1327,6 +1338,7 @@
 				A3049B7F2D160C03002F3166 /* GetTabsRequest.swift in Sources */,
 				A373DC372D28285300215019 /* ModuleItem.swift in Sources */,
 				A306ED112CEAC09E00556D1E /* Folder.swift in Sources */,
+				B7E073622D986DD300A7E82F /* ToDoItemCount.swift in Sources */,
 				A373DC272D1D4C4A00215019 /* QuizSubmissionWorkflowState.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/CanvasPlusPlayground.xcodeproj/project.pbxproj
+++ b/CanvasPlusPlayground.xcodeproj/project.pbxproj
@@ -189,6 +189,11 @@
 		B7CC4D5C2D90C00B00254F55 /* CGSize+Center.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7CC4D5B2D90C00800254F55 /* CGSize+Center.swift */; };
 		B7CC4D5F2D90C86C00254F55 /* Gradient.metal in Resources */ = {isa = PBXBuildFile; fileRef = B7CC4D5E2D90C86C00254F55 /* Gradient.metal */; };
 		B7CC4D632D90C8DB00254F55 /* ShapeStyle+Gradient.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7CC4D622D90C8D500254F55 /* ShapeStyle+Gradient.swift */; };
+		B7CC4D672D91AF4300254F55 /* GetUserTodoItemsRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7CC4D662D91AF3B00254F55 /* GetUserTodoItemsRequest.swift */; };
+		B7CC4D6A2D91AF8200254F55 /* ToDoItemAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7CC4D692D91AF7500254F55 /* ToDoItemAPI.swift */; };
+		B7CC4D6E2D91B27200254F55 /* ToDoItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7CC4D6D2D91B26F00254F55 /* ToDoItem.swift */; };
+		B7CC4D712D91C9FB00254F55 /* ToDoListManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7CC4D702D91C9EE00254F55 /* ToDoListManager.swift */; };
+		B7CC4D732D91D14600254F55 /* ToDoListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7CC4D722D91D14300254F55 /* ToDoListView.swift */; };
 		B7D7512B2D3D5D8000F7B8B8 /* AllAnnouncementsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7D7512A2D3D5D7700F7B8B8 /* AllAnnouncementsView.swift */; };
 		B7D7512D2D3D652300F7B8B8 /* GetAnnouncementsBatchRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7D7512C2D3D652300F7B8B8 /* GetAnnouncementsBatchRequest.swift */; };
 		B7D7512F2D3D660B00F7B8B8 /* AllAnnouncementsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7D7512E2D3D660B00F7B8B8 /* AllAnnouncementsManager.swift */; };
@@ -391,6 +396,11 @@
 		B7CC4D5B2D90C00800254F55 /* CGSize+Center.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CGSize+Center.swift"; sourceTree = "<group>"; };
 		B7CC4D5E2D90C86C00254F55 /* Gradient.metal */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.metal; path = Gradient.metal; sourceTree = "<group>"; };
 		B7CC4D622D90C8D500254F55 /* ShapeStyle+Gradient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ShapeStyle+Gradient.swift"; sourceTree = "<group>"; };
+		B7CC4D662D91AF3B00254F55 /* GetUserTodoItemsRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetUserTodoItemsRequest.swift; sourceTree = "<group>"; };
+		B7CC4D692D91AF7500254F55 /* ToDoItemAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToDoItemAPI.swift; sourceTree = "<group>"; };
+		B7CC4D6D2D91B26F00254F55 /* ToDoItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToDoItem.swift; sourceTree = "<group>"; };
+		B7CC4D702D91C9EE00254F55 /* ToDoListManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToDoListManager.swift; sourceTree = "<group>"; };
+		B7CC4D722D91D14300254F55 /* ToDoListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToDoListView.swift; sourceTree = "<group>"; };
 		B7D7512A2D3D5D7700F7B8B8 /* AllAnnouncementsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AllAnnouncementsView.swift; sourceTree = "<group>"; };
 		B7D7512C2D3D652300F7B8B8 /* GetAnnouncementsBatchRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetAnnouncementsBatchRequest.swift; sourceTree = "<group>"; };
 		B7D7512E2D3D660B00F7B8B8 /* AllAnnouncementsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AllAnnouncementsManager.swift; sourceTree = "<group>"; };
@@ -443,6 +453,7 @@
 		A3049B732D15DBEE002F3166 /* API Requests */ = {
 			isa = PBXGroup;
 			children = (
+				B7CC4D662D91AF3B00254F55 /* GetUserTodoItemsRequest.swift */,
 				B7A12F3E2D69440F00EDFA0A /* GetAssignmentGroupsRequest.swift */,
 				B7D7512C2D3D652300F7B8B8 /* GetAnnouncementsBatchRequest.swift */,
 				A3049B762D15DC36002F3166 /* GetCourseRequest.swift */,
@@ -482,6 +493,7 @@
 		A324BA502D07963D005F53FA /* Features */ = {
 			isa = PBXGroup;
 			children = (
+				B7CC4D682D91AF5800254F55 /* ToDoItems */,
 				9BF228C62D6CD1DF000676F2 /* Reminders */,
 				A373DC2E2D28174700215019 /* Modules */,
 				B7C5532A2D2D5AEB009CF4F0 /* Pinned Items */,
@@ -961,6 +973,25 @@
 			path = Views;
 			sourceTree = "<group>";
 		};
+		B7CC4D682D91AF5800254F55 /* ToDoItems */ = {
+			isa = PBXGroup;
+			children = (
+				B7CC4D6F2D91C9C600254F55 /* Models */,
+				B7CC4D702D91C9EE00254F55 /* ToDoListManager.swift */,
+				B7CC4D722D91D14300254F55 /* ToDoListView.swift */,
+			);
+			path = ToDoItems;
+			sourceTree = "<group>";
+		};
+		B7CC4D6F2D91C9C600254F55 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				B7CC4D692D91AF7500254F55 /* ToDoItemAPI.swift */,
+				B7CC4D6D2D91B26F00254F55 /* ToDoItem.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
 		B7D95DB52D0A8D6A002AD955 /* Settings */ = {
 			isa = PBXGroup;
 			children = (
@@ -1163,6 +1194,8 @@
 				A3049B5B2D0E5C18002F3166 /* QuizPermissions.swift in Sources */,
 				B7C0A3C52D2F4C19003E5A36 /* GetAssignmentRequest.swift in Sources */,
 				A37AB4A92D9867D600610639 /* UpdateGroupMembershipRequest.swift in Sources */,
+				B7CC4D6A2D91AF8200254F55 /* ToDoItemAPI.swift in Sources */,
+				A3FFD03E2CE0065A006BAB51 /* NetworkError.swift in Sources */,
 				B7E59A142D2004A4001836FE /* CourseListCell.swift in Sources */,
 				B53D95A22CA0A22A00647EE9 /* PeopleView.swift in Sources */,
 				A373DC312D28176100215019 /* APIModule.swift in Sources */,
@@ -1214,6 +1247,8 @@
 				9B9C2E042C93F6CD00E4B16B /* CourseAnnouncementsView.swift in Sources */,
 				B77FD0022D52A0D60049AA5E /* ProfileView.swift in Sources */,
 				9A977E8B2D6C375E001D7F0A /* ColorPickerSheet.swift in Sources */,
+				B7CC4D712D91C9FB00254F55 /* ToDoListManager.swift in Sources */,
+				B7CC4D732D91D14600254F55 /* ToDoListView.swift in Sources */,
 				192EC04C2C963EE600AF8528 /* CourseAssignmentsView.swift in Sources */,
 				A372D10C2D90E875005E94CA /* GroupsListView.swift in Sources */,
 				A3FFD03C2CDED67C006BAB51 /* String+Numbers.swift in Sources */,
@@ -1234,6 +1269,7 @@
 				A35191412D283589001E415F /* ModulesViewModel.swift in Sources */,
 				A3E7F3912C99317100DC4300 /* CourseTabsManager.swift in Sources */,
 				A372D0FF2D90BAB6005E94CA /* CourseGroupsView.swift in Sources */,
+				B7CC4D672D91AF4300254F55 /* GetUserTodoItemsRequest.swift in Sources */,
 				9B6D4F802D6E48340033044F /* ReminderButton.swift in Sources */,
 				A3E7F38F2C96C1CE00DC4300 /* CourseTabsView.swift in Sources */,
 				B76455062C8DF61B002DF00E /* CanvasPlusPlaygroundApp.swift in Sources */,
@@ -1253,6 +1289,7 @@
 				A351913F2D283556001E415F /* ModulesListView.swift in Sources */,
 				A3CF88DF2D1921B5000ACDF3 /* FileAPI.swift in Sources */,
 				B7CC4D3C2D8DB87200254F55 /* URL+AppRootURL.swift in Sources */,
+				B7CC4D6E2D91B27200254F55 /* ToDoItem.swift in Sources */,
 				A3CF88DD2D1921A7000ACDF3 /* QuizAPI.swift in Sources */,
 				A3049B532D0E5241002F3166 /* Quiz.swift in Sources */,
 				A3049B872D16146D002F3166 /* GetQuizzesRequest.swift in Sources */,

--- a/CanvasPlusPlayground/CanvasPlusPlaygroundApp.swift
+++ b/CanvasPlusPlayground/CanvasPlusPlaygroundApp.swift
@@ -13,6 +13,7 @@ struct CanvasPlusPlaygroundApp: App {
     @State private var navigationModel = NavigationModel()
 
     // App
+    @State private var listManager = ToDoListManager()
     @State private var profileManager = ProfileManager()
     @State private var courseManager = CourseManager()
     @State private var pinnedItemsManager = PinnedItemsManager()
@@ -23,6 +24,7 @@ struct CanvasPlusPlaygroundApp: App {
     var body: some Scene {
         WindowGroup {
             HomeView()
+                .environment(listManager)
                 .environment(profileManager)
                 .environment(courseManager)
                 .environment(pinnedItemsManager)

--- a/CanvasPlusPlayground/Common/Network/API Requests/GetUserTodoItemCountRequest.swift
+++ b/CanvasPlusPlayground/Common/Network/API Requests/GetUserTodoItemCountRequest.swift
@@ -1,0 +1,49 @@
+//
+//  GetUserTodoItemCountRequest.swift
+//  CanvasPlusPlayground
+//
+//  Created by Rahul on 3/29/25.
+//
+
+import Foundation
+
+struct GetUserTodoItemCountRequest: CacheableAPIRequest {
+    typealias Subject = ToDoItemCountAPI
+
+    var path: String { "users/self/todo_item_count" }
+
+    var queryParameters: [QueryParameter] {
+        include.map { ("include[]", $0.rawValue) }
+    }
+
+    // MARK: Query Params
+    let include: [Include]
+
+    init(include: [Include] = []) {
+        self.include = include
+    }
+
+    var requestId: String {
+        "todos_count_\(StorageKeys.accessTokenValue)"
+    }
+
+    var requestIdKey: ParentKeyPath<ToDoItemCount, String> {
+        .createWritable(\.parentID)
+    }
+
+    var idPredicate: Predicate<ToDoItemCount> {
+        #Predicate<ToDoItemCount> { item in
+            item.parentID == requestId
+        }
+    }
+
+    var customPredicate: Predicate<ToDoItemCount> {
+        .true
+    }
+}
+
+extension GetUserTodoItemCountRequest {
+    enum Include: String {
+        case ungradedQuizzes = "ungraded_quizzes"
+    }
+}

--- a/CanvasPlusPlayground/Common/Network/API Requests/GetUserTodoItemsRequest.swift
+++ b/CanvasPlusPlayground/Common/Network/API Requests/GetUserTodoItemsRequest.swift
@@ -1,0 +1,51 @@
+//
+//  GetUserTodoItemsRequest.swift
+//  CanvasPlusPlayground
+//
+//  Created by Rahul on 3/24/25.
+//
+
+import Foundation
+
+struct GetUserTodoItemsRequest: CacheableArrayAPIRequest {
+    typealias Subject = ToDoItemAPI
+
+    var path: String {
+        "users/self/todo"
+    }
+
+    var queryParameters: [QueryParameter] {
+        include.map { ("include[]", $0.rawValue) }
+    }
+
+    // MARK: Query Params
+    let include: [Include]
+
+    init(include: [Include] = []) {
+        self.include = include
+    }
+
+    var requestId: String {
+        "todos_\(StorageKeys.accessTokenValue)"
+    }
+
+    var requestIdKey: ParentKeyPath<ToDoItem, String> {
+        .createWritable(\.parentID)
+    }
+
+    var idPredicate: Predicate<ToDoItem> {
+        #Predicate<ToDoItem> { item in
+            item.parentID == requestId
+        }
+    }
+
+    var customPredicate: Predicate<ToDoItem> {
+        .true
+    }
+}
+
+extension GetUserTodoItemsRequest {
+    enum Include: String {
+        case ungradedQuizzes = "ungraded_quizzes"
+    }
+}

--- a/CanvasPlusPlayground/Common/Network/API Requests/GetUserTodoItemsRequest.swift
+++ b/CanvasPlusPlayground/Common/Network/API Requests/GetUserTodoItemsRequest.swift
@@ -15,7 +15,10 @@ struct GetUserTodoItemsRequest: CacheableArrayAPIRequest {
     }
 
     var queryParameters: [QueryParameter] {
-        include.map { ("include[]", $0.rawValue) }
+        [
+            ("per_page", 100)
+        ]
+        + include.map { ("include[]", $0.rawValue) }
     }
 
     // MARK: Query Params

--- a/CanvasPlusPlayground/Common/Network/API Requests/IgnoreToDoItemRequest.swift
+++ b/CanvasPlusPlayground/Common/Network/API Requests/IgnoreToDoItemRequest.swift
@@ -1,0 +1,15 @@
+//
+//  MarkCourseDiscussionTopicUnreadRequest 2.swift
+//  CanvasPlusPlayground
+//
+//  Created by Rahul on 3/29/25.
+//
+
+struct IgnoreToDoItemRequest: NoReturnAPIRequest {
+    let ignoreURL: String
+
+    var path: String { "" }
+    var forceURL: String? { ignoreURL }
+    var method: RequestMethod { .DELETE }
+    var queryParameters: [QueryParameter] { [] }
+}

--- a/CanvasPlusPlayground/Common/Network/CanvasRequest.swift
+++ b/CanvasPlusPlayground/Common/Network/CanvasRequest.swift
@@ -29,6 +29,10 @@ enum CanvasRequest {
         GetUserTodoItemCountRequest(include: include)
     }
 
+    static func ignoreToDoItem(ignoreURL: String) -> IgnoreToDoItemRequest {
+        IgnoreToDoItemRequest(ignoreURL: ignoreURL)
+    }
+
     static func getCourseRootFolder(courseId: String) -> GetCourseRootFolderRequest {
         GetCourseRootFolderRequest(courseId: courseId)
     }

--- a/CanvasPlusPlayground/Common/Network/CanvasRequest.swift
+++ b/CanvasPlusPlayground/Common/Network/CanvasRequest.swift
@@ -17,6 +17,12 @@ enum CanvasRequest {
         GetCourseRequest(courseId: id)
     }
 
+    static func getToDoItems(
+        include: [GetUserTodoItemsRequest.Include] = []
+    ) -> GetUserTodoItemsRequest {
+        GetUserTodoItemsRequest(include: include)
+    }
+
     static func getCourseRootFolder(courseId: String) -> GetCourseRootFolderRequest {
         GetCourseRootFolderRequest(courseId: courseId)
     }

--- a/CanvasPlusPlayground/Common/Network/CanvasRequest.swift
+++ b/CanvasPlusPlayground/Common/Network/CanvasRequest.swift
@@ -23,6 +23,12 @@ enum CanvasRequest {
         GetUserTodoItemsRequest(include: include)
     }
 
+    static func getToDoItemCount(
+        include: [GetUserTodoItemCountRequest.Include] = []
+    ) -> GetUserTodoItemCountRequest {
+        GetUserTodoItemCountRequest(include: include)
+    }
+
     static func getCourseRootFolder(courseId: String) -> GetCourseRootFolderRequest {
         GetCourseRootFolderRequest(courseId: courseId)
     }

--- a/CanvasPlusPlayground/Common/Storage/CanvasRepository.swift
+++ b/CanvasPlusPlayground/Common/Storage/CanvasRepository.swift
@@ -85,7 +85,9 @@ extension ModelContext {
             DiscussionTopic.self,
             Page.self,
             CanvasGroup.self,
-            GroupMembership.self
+            GroupMembership.self,
+            ToDoItem.self,
+            ToDoItemCount.self
             // TODO: Add cacheable models here
         )
 

--- a/CanvasPlusPlayground/Features/Navigation/HomeView.swift
+++ b/CanvasPlusPlayground/Features/Navigation/HomeView.swift
@@ -101,21 +101,26 @@ struct HomeView: View {
         @Bindable var navigationModel = navigationModel
 
         NavigationStack(path: $navigationModel.navigationPath) {
-            if let selectedCourse {
-                CourseView(course: selectedCourse)
-            } else if let selectedNavigationPage {
-                switch selectedNavigationPage {
-                case .announcements:
-                    AllAnnouncementsView()
-                case .toDoList:
-                    AggregatedAssignmentsView()
-                case .pinned:
-                    PinnedItemsView()
-                default:
-                    EmptyView()
+            Group {
+                if let selectedCourse {
+                    CourseView(course: selectedCourse)
+                } else if let selectedNavigationPage {
+                    switch selectedNavigationPage {
+                    case .announcements:
+                        AllAnnouncementsView()
+                    case .toDoList:
+                        ToDoListView()
+                    case .pinned:
+                        PinnedItemsView()
+                    default:
+                        EmptyView()
+                    }
+                } else {
+                    ContentUnavailableView("Select a course", systemImage: "folder")
                 }
-            } else {
-                ContentUnavailableView("Select a course", systemImage: "folder")
+            }
+            .navigationDestination(for: NavigationModel.Destination.self) { destination in
+                destination.destinationView(for: selectedCourse)
             }
         }
     }

--- a/CanvasPlusPlayground/Features/Navigation/HomeView.swift
+++ b/CanvasPlusPlayground/Features/Navigation/HomeView.swift
@@ -102,10 +102,10 @@ struct HomeView: View {
         @Bindable var navigationModel = navigationModel
 
         NavigationStack(path: $navigationModel.navigationPath) {
-            Group {
-                if let selectedCourse {
-                    CourseView(course: selectedCourse)
-                } else if let selectedNavigationPage {
+            if let selectedCourse {
+                CourseView(course: selectedCourse)
+            } else if let selectedNavigationPage {
+                Group {
                     switch selectedNavigationPage {
                     case .announcements:
                         AllAnnouncementsView()
@@ -116,12 +116,12 @@ struct HomeView: View {
                     default:
                         EmptyView()
                     }
-                } else {
-                    ContentUnavailableView("Select a course", systemImage: "folder")
                 }
-            }
-            .navigationDestination(for: NavigationModel.Destination.self) { destination in
-                destination.destinationView(for: selectedCourse)
+                .navigationDestination(for: NavigationModel.Destination.self) { destination in
+                    destination.destinationView(for: selectedCourse)
+                }
+            } else {
+                ContentUnavailableView("Select a course", systemImage: "folder")
             }
         }
     }

--- a/CanvasPlusPlayground/Features/Navigation/HomeView.swift
+++ b/CanvasPlusPlayground/Features/Navigation/HomeView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct HomeView: View {
     typealias NavigationPage = NavigationModel.NavigationPage
 
+    @Environment(ToDoListManager.self) private var toDoListManager
     @Environment(ProfileManager.self) private var profileManager
     @Environment(CourseManager.self) private var courseManager
     @Environment(NavigationModel.self) private var navigationModel
@@ -129,6 +130,7 @@ struct HomeView: View {
         isLoadingCourses = true
         await courseManager.getCourses()
         await profileManager.getCurrentUserAndProfile()
+        await toDoListManager.fetchToDoItemCount()
         isLoadingCourses = false
     }
 }

--- a/CanvasPlusPlayground/Features/Navigation/NavigationModel.swift
+++ b/CanvasPlusPlayground/Features/Navigation/NavigationModel.swift
@@ -97,6 +97,7 @@ class NavigationModel {
     }
 
     enum Destination: Hashable {
+        case course(Course)
         case coursePage(CoursePage)
 
         case announcement(DiscussionTopic)
@@ -105,10 +106,14 @@ class NavigationModel {
         // TODO: Add specific course items as needed.
 
         @ViewBuilder
-        func destinationView(for course: Course) -> some View {
+        func destinationView(for course: Course?) -> some View {
             switch self {
+            case .course(let course):
+                CourseView(course: course)
             case .coursePage(let coursePage):
-                CourseDetailView(course: course, coursePage: coursePage)
+                if let course {
+                    CourseDetailView(course: course, coursePage: coursePage)
+                }
             case .announcement(let announcement):
                 CourseAnnouncementDetailView(announcement: announcement)
             case .assignment(let assignment):

--- a/CanvasPlusPlayground/Features/Navigation/Sidebar.swift
+++ b/CanvasPlusPlayground/Features/Navigation/Sidebar.swift
@@ -106,6 +106,7 @@ private struct SidebarCourseCell: View {
 }
 
 private struct SidebarTiles: View {
+    @Environment(ToDoListManager.self) private var toDoListManager
     @Environment(NavigationModel.self) private var navigationModel
 
     var body: some View {
@@ -136,6 +137,7 @@ private struct SidebarTiles: View {
 
             SidebarTile(
                 "To-Do",
+                count: toDoListManager.toDoItemCount,
                 systemIcon: "list.bullet.circle.fill",
                 color: .red,
                 page: .toDoList

--- a/CanvasPlusPlayground/Features/Navigation/Sidebar.swift
+++ b/CanvasPlusPlayground/Features/Navigation/Sidebar.swift
@@ -144,7 +144,6 @@ private struct SidebarTiles: View {
             ) {
                 navigationModel.selectedNavigationPage = .toDoList
             }
-            .disabled(true) // TODO: Re-enable with TODOs PR.
 
             SidebarTile(
                 "Pinned",

--- a/CanvasPlusPlayground/Features/Navigation/SidebarTile.swift
+++ b/CanvasPlusPlayground/Features/Navigation/SidebarTile.swift
@@ -11,6 +11,7 @@ struct SidebarTile: View {
     @Environment(NavigationModel.self) private var navigationModel
 
     let title: String
+    let count: Int?
     let systemIcon: String
     let color: Color
     let page: NavigationModel.NavigationPage
@@ -18,12 +19,14 @@ struct SidebarTile: View {
 
     init(
         _ title: String,
+        count: Int? = nil,
         systemIcon: String,
         color: Color,
         page: NavigationModel.NavigationPage,
         action: @escaping () -> Void
     ) {
         self.title = title
+        self.count = count
         self.systemIcon = systemIcon
         self.color = color
         self.page = page
@@ -50,6 +53,15 @@ struct SidebarTile: View {
                     .foregroundStyle(.tint)
 
                 Spacer()
+
+                if let count {
+                    Text("\(count)")
+                        .font(.title3)
+                        .fontDesign(.rounded)
+                        .bold()
+                        .foregroundStyle(isSelected ? .white : .primary)
+                        .contentTransition(.numericText())
+                }
             }
             Text(title)
                 .foregroundStyle(isSelected ? .white : .primary)
@@ -72,5 +84,6 @@ struct SidebarTile: View {
         .frame(minWidth: 90)
         #endif
         .tint(color)
+        .animation(.default, value: count)
     }
 }

--- a/CanvasPlusPlayground/Features/ToDoItems/Models/ToDoItem.swift
+++ b/CanvasPlusPlayground/Features/ToDoItems/Models/ToDoItem.swift
@@ -1,0 +1,98 @@
+//
+//  ToDoItem.swift
+//  CanvasPlusPlayground
+//
+//  Created by Rahul on 3/24/25.
+//
+
+import Foundation
+import SwiftData
+
+@Model
+class ToDoItem: Cacheable {
+    typealias ID = String
+
+    @Attribute(.unique)
+    let id: String
+    var parentID: String
+
+    var contextType: ToDoItemContextType
+    var courseID: Int
+    var groupID: Int?
+    var contextName: String
+    var type: ToDoItemType
+    var ignoreURL: String
+    var ignorePermanentlyURL: String
+    var assignment: Assignment?
+    var quiz: Quiz?
+    var htmlURL: String
+
+    // MARK: Custom Properties
+    @Transient
+    var course: Course?
+
+    // MARK: Computed Properties
+    var title: String {
+        assignment?.name ?? quiz?.title ?? "Unknown Item"
+    }
+
+    var dueDate: Date? {
+        assignment?.dueDate ?? quiz?.dueAt
+    }
+
+    var itemType: ItemType? {
+        if let assignment {
+            return .assignment(assignment)
+        } else if let quiz {
+            return .quiz(quiz)
+        }
+
+        return nil
+    }
+
+    init(from toDoItemAPI: ToDoItemAPI) {
+        self.id = toDoItemAPI.id
+        self.parentID = ""
+        self.contextType = toDoItemAPI.contextType
+        self.courseID = toDoItemAPI.courseID
+        self.groupID = toDoItemAPI.groupID
+        self.contextName = toDoItemAPI.contextName
+        self.type = toDoItemAPI.type
+        self.ignoreURL = toDoItemAPI.ignoreURL
+        self.ignorePermanentlyURL = toDoItemAPI.ignorePermanentlyURL
+        self.assignment = toDoItemAPI.assignment?.createModel()
+        self.quiz = toDoItemAPI.quiz?.createModel()
+        self.htmlURL = toDoItemAPI.htmlURL
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case contextType = "context_type"
+        case courseID = "course_id"
+        case groupID = "group_id"
+        case contextName = "context_name"
+        case type
+        case ignoreURL = "ignore"
+        case ignorePermanentlyURL = "ignore_permanently"
+        case assignment
+        case quiz
+        case htmlURL = "html_url"
+    }
+
+    func merge(with other: ToDoItem) {
+        self.contextType = other.contextType
+        self.courseID = other.courseID
+        self.groupID = other.groupID
+        self.contextName = other.contextName
+        self.type = other.type
+        self.ignoreURL = other.ignoreURL
+        self.ignorePermanentlyURL = other.ignorePermanentlyURL
+        self.assignment = other.assignment
+        self.quiz = other.quiz
+        self.htmlURL = other.htmlURL
+    }
+
+    enum ItemType {
+        case assignment(Assignment)
+        case quiz(Quiz)
+    }
+}

--- a/CanvasPlusPlayground/Features/ToDoItems/Models/ToDoItemAPI.swift
+++ b/CanvasPlusPlayground/Features/ToDoItems/Models/ToDoItemAPI.swift
@@ -1,0 +1,61 @@
+//
+//  ToDoItemAPI.swift
+//  CanvasPlusPlayground
+//
+//  Created by Rahul on 3/24/25.
+//
+
+import Foundation
+
+struct ToDoItemAPI: Identifiable, APIResponse {
+    typealias Model = ToDoItem
+
+    let contextType: ToDoItemContextType
+    let courseID: Int
+    let groupID: Int?
+    let contextName: String
+    let type: ToDoItemType
+    let ignoreURL: String
+    let ignorePermanentlyURL: String
+    let assignment: AssignmentAPI?
+    let quiz: QuizAPI?
+    let htmlURL: String
+
+    enum CodingKeys: String, CodingKey {
+        case contextType = "context_type"
+        case courseID = "course_id"
+        case groupID = "group_id"
+        case contextName = "context_name"
+        case type
+        case ignoreURL = "ignore"
+        case ignorePermanentlyURL = "ignore_permanently"
+        case assignment
+        case quiz
+        case htmlURL = "html_url"
+    }
+
+    // Not included with API Response, so we need to synthesize it.
+    var id: String {
+        if let assignmentID = assignment?.id.asString {
+            return assignmentID
+        } else if let quizID = quiz?.id.asString {
+            return quizID
+        }
+
+        return UUID().uuidString
+    }
+
+    func createModel() -> ToDoItem {
+        ToDoItem(from: self)
+    }
+}
+
+enum ToDoItemContextType: String, Codable {
+    case course = "Course"
+    case group = "Group"
+}
+
+enum ToDoItemType: String, Codable {
+    case grading
+    case submitting
+}

--- a/CanvasPlusPlayground/Features/ToDoItems/Models/ToDoItemCount.swift
+++ b/CanvasPlusPlayground/Features/ToDoItems/Models/ToDoItemCount.swift
@@ -1,0 +1,38 @@
+//
+//  ToDoItemCount.swift
+//  CanvasPlusPlayground
+//
+//  Created by Rahul on 3/29/25.
+//
+
+import Foundation
+import SwiftData
+
+@Model
+class ToDoItemCount: Cacheable {
+    typealias ID = String
+
+    @Attribute(.unique)
+    let id: String
+    var parentID: String
+
+    var needsGradingCount: Int
+    var assignmentsNeedingSubmitting: Int
+
+    init(from model: ToDoItemCountAPI) {
+        self.id = UUID().uuidString // not included with API
+        self.parentID = ""
+        self.needsGradingCount = model.needsGradingCount
+        self.assignmentsNeedingSubmitting = model.assignmentsNeedingSubmitting
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case needsGradingCount = "needs_grading_count"
+        case assignmentsNeedingSubmitting = "assignments_needing_submitting"
+    }
+
+    func merge(with other: ToDoItemCount) {
+        self.needsGradingCount = other.needsGradingCount
+        self.assignmentsNeedingSubmitting = other.assignmentsNeedingSubmitting
+    }
+}

--- a/CanvasPlusPlayground/Features/ToDoItems/Models/ToDoItemCountAPI.swift
+++ b/CanvasPlusPlayground/Features/ToDoItems/Models/ToDoItemCountAPI.swift
@@ -1,0 +1,24 @@
+//
+//  ToDoItemCount.swift
+//  CanvasPlusPlayground
+//
+//  Created by Rahul on 3/29/25.
+//
+
+import Foundation
+
+struct ToDoItemCountAPI: APIResponse {
+    typealias Model = ToDoItemCount
+
+    let needsGradingCount: Int
+    let assignmentsNeedingSubmitting: Int
+
+    enum CodingKeys: String, CodingKey {
+        case needsGradingCount = "needs_grading_count"
+        case assignmentsNeedingSubmitting = "assignments_needing_submitting"
+    }
+
+    func createModel() -> ToDoItemCount {
+        ToDoItemCount(from: self)
+    }
+}

--- a/CanvasPlusPlayground/Features/ToDoItems/ToDoListManager.swift
+++ b/CanvasPlusPlayground/Features/ToDoItems/ToDoListManager.swift
@@ -45,7 +45,8 @@ class ToDoListManager {
                     request,
                     onCacheReceive: { cached in
                         guard let cached else { return }
-                        toDoItems = cached
+                        toDoItems = []
+                        self.addItems(cached, to: &toDoItems, courses: courses)
                     },
                     loadingMethod: .all(onNewPage: { items in
                         self.addItems(items, to: &newItems, courses: courses)

--- a/CanvasPlusPlayground/Features/ToDoItems/ToDoListManager.swift
+++ b/CanvasPlusPlayground/Features/ToDoItems/ToDoListManager.swift
@@ -61,6 +61,14 @@ class ToDoListManager {
                         }
                     })
                 )
+
+            Task { @MainActor in
+                self.addItems(
+                    items,
+                    courses: courses,
+                    replaceExisting: true
+                )
+            }
         } catch {
             LoggerService.main.error("Failed to fetch to-do items: \(error)")
         }

--- a/CanvasPlusPlayground/Features/ToDoItems/ToDoListManager.swift
+++ b/CanvasPlusPlayground/Features/ToDoItems/ToDoListManager.swift
@@ -1,0 +1,41 @@
+//
+//  ToDoListManager.swift
+//  CanvasPlusPlayground
+//
+//  Created by Rahul on 3/24/25.
+//
+
+import SwiftUI
+
+@Observable
+class ToDoListManager {
+    var toDoItems: [ToDoItem] = []
+
+    func fetchToDoItems(courses: [Course]) async {
+        let request = CanvasRequest.getToDoItems()
+
+        var newItems = [ToDoItem]()
+
+        do {
+            let items: [ToDoItem]? = try await CanvasService.shared
+                .loadAndSync(
+                    request,
+                    onCacheReceive: { cached in
+                        guard let cached else { return }
+                        toDoItems = cached
+                    },
+                    loadingMethod: .all(onNewPage: { items in
+                        newItems.append(contentsOf: items)
+                    })
+                )
+        } catch {
+            LoggerService.main.error("Failed to fetch to-do items: \(error)")
+        }
+
+        newItems.forEach { item in
+            item.course = courses.first { $0.id == item.courseID.asString }
+        }
+
+        toDoItems = newItems
+    }
+}

--- a/CanvasPlusPlayground/Features/ToDoItems/ToDoListManager.swift
+++ b/CanvasPlusPlayground/Features/ToDoItems/ToDoListManager.swift
@@ -49,7 +49,9 @@ class ToDoListManager {
                         self.addItems(cached, to: &toDoItems, courses: courses)
                     },
                     loadingMethod: .all(onNewPage: { items in
-                        self.addItems(items, to: &newItems, courses: courses)
+                        Task { @MainActor in
+                            self.addItems(items, to: &newItems, courses: courses)
+                        }
                     })
                 )
         } catch {

--- a/CanvasPlusPlayground/Features/ToDoItems/ToDoListManager.swift
+++ b/CanvasPlusPlayground/Features/ToDoItems/ToDoListManager.swift
@@ -13,7 +13,9 @@ class ToDoListManager {
     var toDoItemCount: Int?
 
     func fetchToDoItemCount() async {
-        let request = CanvasRequest.getToDoItemCount()
+        let request = CanvasRequest.getToDoItemCount(
+            include: [.ungradedQuizzes]
+        )
 
         do {
             let count: [ToDoItemCount]? = try await CanvasService.shared
@@ -32,7 +34,7 @@ class ToDoListManager {
     }
 
     func fetchToDoItems(courses: [Course]) async {
-        let request = CanvasRequest.getToDoItems()
+        let request = CanvasRequest.getToDoItems(include: [.ungradedQuizzes])
 
         var newItems = [ToDoItem]()
 

--- a/CanvasPlusPlayground/Features/ToDoItems/ToDoListManager.swift
+++ b/CanvasPlusPlayground/Features/ToDoItems/ToDoListManager.swift
@@ -58,4 +58,14 @@ class ToDoListManager {
 
         toDoItems = newItems
     }
+
+    func ignoreToDoItem(_ item: ToDoItem) async {
+        let request = CanvasRequest.ignoreToDoItem(ignoreURL: item.ignoreURL)
+
+        do {
+            try await CanvasService.shared.fetch(request)
+        } catch {
+            LoggerService.main.error("Failed to ignore todo item: \(error)")
+        }
+    }
 }

--- a/CanvasPlusPlayground/Features/ToDoItems/ToDoListManager.swift
+++ b/CanvasPlusPlayground/Features/ToDoItems/ToDoListManager.swift
@@ -60,6 +60,10 @@ class ToDoListManager {
     }
 
     func ignoreToDoItem(_ item: ToDoItem) async {
+        // We can either use the ignoreURL or the ignorePermanentlyURL.
+        // ignoreURL will add the item back if the item is updated in the future.
+        // ignorePermanentlyURL will remove the item from the list forever.
+
         let request = CanvasRequest.ignoreToDoItem(ignoreURL: item.ignoreURL)
 
         do {

--- a/CanvasPlusPlayground/Features/ToDoItems/ToDoListManager.swift
+++ b/CanvasPlusPlayground/Features/ToDoItems/ToDoListManager.swift
@@ -10,6 +10,26 @@ import SwiftUI
 @Observable
 class ToDoListManager {
     var toDoItems: [ToDoItem] = []
+    var toDoItemCount: Int?
+
+    func fetchToDoItemCount() async {
+        let request = CanvasRequest.getToDoItemCount()
+
+        do {
+            let count: [ToDoItemCount]? = try await CanvasService.shared
+                .loadAndSync(
+                    request,
+                    onCacheReceive: { cached in
+                        guard let cached = cached?.first else { return }
+                        self.toDoItemCount = cached.assignmentsNeedingSubmitting
+                    }
+                )
+
+            self.toDoItemCount = count?.first?.assignmentsNeedingSubmitting
+        } catch {
+            LoggerService.main.error("Failed to fetch to-do item count: \(error)")
+        }
+    }
 
     func fetchToDoItems(courses: [Course]) async {
         let request = CanvasRequest.getToDoItems()

--- a/CanvasPlusPlayground/Features/ToDoItems/ToDoListManager.swift
+++ b/CanvasPlusPlayground/Features/ToDoItems/ToDoListManager.swift
@@ -24,11 +24,7 @@ class ToDoListManager {
         do {
             let count: [ToDoItemCount]? = try await CanvasService.shared
                 .loadAndSync(
-                    request,
-                    onCacheReceive: { cached in
-                        guard let cached = cached?.first else { return }
-                        self.toDoItemCount = cached.assignmentsNeedingSubmitting
-                    }
+                    request
                 )
 
             // TODO: If we support grading assignments, add that count

--- a/CanvasPlusPlayground/Features/ToDoItems/ToDoListView.swift
+++ b/CanvasPlusPlayground/Features/ToDoItems/ToDoListView.swift
@@ -15,8 +15,8 @@ struct ToDoListView: View {
     @State private var isLoading = false
     @State private var filterCourse: Course?
 
-    private var filterCourseOptions: [Course] {
-        listManager.toDoItems.compactMap(\.course)
+    private var filterCourseOptions: Set<Course> {
+        Set(listManager.toDoItems.compactMap(\.course))
     }
 
     private var displayedResults: [ToDoItem] {
@@ -81,7 +81,7 @@ struct ToDoListView: View {
         ) {
             Text("All Items").tag(Optional<Course>.none)
 
-            ForEach(filterCourseOptions) { course in
+            ForEach(Array(filterCourseOptions)) { course in
                 Text(course.displayName).tag(course)
             }
         } label: {

--- a/CanvasPlusPlayground/Features/ToDoItems/ToDoListView.swift
+++ b/CanvasPlusPlayground/Features/ToDoItems/ToDoListView.swift
@@ -15,15 +15,16 @@ struct ToDoListView: View {
     @State private var isLoading = false
     @State private var filterCourse: Course?
 
-    private var filterCourseOptions: Set<Course> {
+    private var filterCourseOptions: [Course] {
         Set(listManager.toDoItems.compactMap(\.course))
+            .sorted { $0.displayName < $1.displayName }
     }
 
     private var displayedResults: [ToDoItem] {
         if let filterCourse {
-            listManager.toDoItems.filter { $0.course == filterCourse }
+            listManager.displayedToDoItems.filter { $0.course == filterCourse }
         } else {
-            listManager.toDoItems
+            listManager.displayedToDoItems
         }
     }
 
@@ -82,7 +83,7 @@ struct ToDoListView: View {
         ) {
             Text("All Items").tag(Optional<Course>.none)
 
-            ForEach(Array(filterCourseOptions)) { course in
+            ForEach(filterCourseOptions) { course in
                 Text(course.displayName).tag(course)
             }
         } label: {

--- a/CanvasPlusPlayground/Features/ToDoItems/ToDoListView.swift
+++ b/CanvasPlusPlayground/Features/ToDoItems/ToDoListView.swift
@@ -143,9 +143,7 @@ private struct ToDoItemRow: View {
         .contextMenu {
             if let course = item.course {
                 Button("Go to Course...", systemImage: "folder") {
-                    navigationModel.navigationPath.append(
-                        NavigationModel.Destination.course(course)
-                    )
+                    navigationModel.selectedNavigationPage = .course(id: course.id)
                 }
             }
 
@@ -163,7 +161,7 @@ private struct ToDoItemRow: View {
     }
 
     private var ignoreItemButton: some View {
-        Button("Ignore Item", systemImage: "trash", role: .destructive) {
+        Button("Ignore Item", systemImage: "eye.slash", role: .destructive) {
             onIgnoreItem()
         }
     }

--- a/CanvasPlusPlayground/Features/ToDoItems/ToDoListView.swift
+++ b/CanvasPlusPlayground/Features/ToDoItems/ToDoListView.swift
@@ -32,6 +32,7 @@ struct ToDoListView: View {
             NavigationLink(value: itemTypeToDestination(for: item)) {
                 ToDoItemRow(item: item) {
                     Task {
+                        await listManager.ignoreToDoItem(item)
                         await loadItems()
                     }
                 }

--- a/CanvasPlusPlayground/Features/ToDoItems/ToDoListView.swift
+++ b/CanvasPlusPlayground/Features/ToDoItems/ToDoListView.swift
@@ -9,8 +9,8 @@ import SwiftUI
 
 struct ToDoListView: View {
     @Environment(CourseManager.self) private var courseManager
+    @Environment(ToDoListManager.self) private var listManager
 
-    @State private var listManager = ToDoListManager()
     @State private var selectedItem: ToDoItem?
     @State private var isLoading = false
     @State private var filterCourse: Course?
@@ -82,6 +82,7 @@ struct ToDoListView: View {
 
     private func loadItems() async {
         isLoading = true
+        await listManager.fetchToDoItemCount()
         await listManager.fetchToDoItems(courses: courseManager.allCourses)
         isLoading = false
     }

--- a/CanvasPlusPlayground/Features/ToDoItems/ToDoListView.swift
+++ b/CanvasPlusPlayground/Features/ToDoItems/ToDoListView.swift
@@ -1,0 +1,142 @@
+//
+//  ToDoListView.swift
+//  CanvasPlusPlayground
+//
+//  Created by Rahul on 3/24/25.
+//
+
+import SwiftUI
+
+struct ToDoListView: View {
+    @Environment(CourseManager.self) private var courseManager
+
+    @State private var listManager = ToDoListManager()
+    @State private var selectedItem: ToDoItem?
+    @State private var isLoading = false
+    @State private var filterCourse: Course?
+
+    private var filterCourseOptions: [Course] {
+        listManager.toDoItems.compactMap(\.course)
+    }
+
+    private var displayedResults: [ToDoItem] {
+        if let filterCourse {
+            listManager.toDoItems.filter { $0.course == filterCourse }
+        } else {
+            listManager.toDoItems
+        }
+    }
+
+    var body: some View {
+        List(displayedResults, selection: $selectedItem) { item in
+            NavigationLink(value: itemTypeToDestination(for: item)) {
+                ToDoItemRow(item: item)
+            }
+            .tag(item)
+        }
+        #if os(iOS)
+        .onAppear {
+            selectedItem = nil
+        }
+        #endif
+        .navigationTitle("To-Do List")
+        .listStyle(.inset)
+        .task(id: courseManager.allCourses) {
+            await loadItems()
+        }
+        .refreshable {
+            await loadItems()
+        }
+        .toolbar {
+            ToolbarItem(placement: .confirmationAction) {
+                #if os(iOS)
+                Menu {
+                    courseFilterPicker
+                } label: {
+                    Image(systemName: "line.3.horizontal.decrease.circle")
+                        .symbolVariant(filterCourse != nil ? .fill : .none)
+                }
+                #else
+                courseFilterPicker
+                #endif
+            }
+        }
+        .statusToolbarItem("To-Dos", isVisible: isLoading)
+    }
+
+    private var courseFilterPicker: some View {
+        Picker(
+            selection: $filterCourse.animation()
+        ) {
+            Text("All Items").tag(Optional<Course>.none)
+
+            ForEach(filterCourseOptions) { course in
+                Text(course.displayName).tag(course)
+            }
+        } label: {
+            Image(systemName: "line.3.horizontal.decrease.circle")
+                .symbolVariant(filterCourse != nil ? .fill : .none)
+        }
+        .labelStyle(.iconOnly)
+    }
+
+    private func loadItems() async {
+        isLoading = true
+        await listManager.fetchToDoItems(courses: courseManager.allCourses)
+        isLoading = false
+    }
+
+    private func itemTypeToDestination(for item: ToDoItem) -> NavigationModel.Destination? {
+        if let type = item.itemType {
+            switch type {
+            case .assignment(let assignment):
+                return .assignment(assignment)
+            case .quiz(let _):
+                // TODO: Support Quiz Detail View
+                return nil
+            }
+        }
+
+        return nil
+    }
+}
+
+private struct ToDoItemRow: View {
+    @Environment(NavigationModel.self) private var navigationModel
+    let item: ToDoItem
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            courseName
+
+            Text(item.title)
+                .bold()
+
+            if let dueDate = item.dueDate {
+                Text("Due ")
+                    .fontWeight(.semibold)
+                +
+                Text(dueDate, style: .date)
+                +
+                Text(" at ")
+                +
+                Text(dueDate, style: .time)
+            }
+        }
+        .contextMenu {
+            if let course = item.course {
+                Button("Go to Course...", systemImage: "folder") {
+                    navigationModel.navigationPath.append(
+                        NavigationModel.Destination.course(course)
+                    )
+                }
+            }
+        }
+    }
+
+    private var courseName: some View {
+        Text(item.course?.displayName.uppercased() ?? "")
+            .font(.caption)
+            .foregroundStyle(item.course?.rgbColors?.color ?? .accentColor)
+    }
+}


### PR DESCRIPTION
Fixes #278

## Changes Made

- Add To Do feature using appropriate requests. Fetch count separately and display using the `SidebarTile`.
- Remove/"Ignore" items using Canvas API. We use the `ignoreURL` for this. 
   - Note: We can either use the `ignoreURL` or the `ignorePermanentlyURL`. `ignoreURL` will add the item back if the item is updated in the future. `ignorePermanentlyURL` will remove the item from the list forever. 
   - Open to suggestions on this
- Filter items by course. 

## Screenshots (if applicable)
rip I don't have items rn

<img width="400" alt="Screenshot 2025-03-29 at 3 09 25 PM" src="https://github.com/user-attachments/assets/a1bec1cc-b4e8-4a9f-a187-22af73517acb" />

## Checklist
- [x] I have implemented all requirements for this PR and its accompanying issue.
- [x] I have verified my implementation across all edge cases.
- [x] I have ensured my changes compile on macOS & iOS.
- [x] I have resolved all SwiftLint warnings.
