### PR TITLE
assignment submissions invalid file type

### DIFF
--- a/CanvasPlusPlayground/Features/Assignments/AssignmentSubmissionManager.swift
+++ b/CanvasPlusPlayground/Features/Assignments/AssignmentSubmissionManager.swift
@@ -167,7 +167,7 @@ public class AssignmentSubmissionManager {
     }
 
     enum AssignmentSubmissionError: LocalizedError {
-        case missingCourseID, notificationResponseFailure, uploadResponseLocationMissing, errorUploadingFiles
+        case missingCourseID, notificationResponseFailure, uploadResponseLocationMissing, errorUploadingFiles, invalidFileType
 
         var errorDescription: String? {
             switch self {
@@ -179,6 +179,8 @@ public class AssignmentSubmissionManager {
                 return "Upload response missing location in header."
             case .errorUploadingFiles:
                 return "Error uploading files."
+            case .invalidFileType:
+                return "Invalid file type."
             }
         }
     }


### PR DESCRIPTION
Fixes #294 

## Changes Made

- modified assignment submission view to restricted file uploads to just file types allowed for the assignment
- displays error on a drag-and-drop of an invalid file type

## Screenshots (if applicable)
![output](https://github.com/user-attachments/assets/7bd71c3a-29bc-4be7-9dd3-85666fc96ef8)

## Checklist
- [x] I have implemented all requirements for this PR and its accompanying issue.
- [x] I have verified my implementation across all edge cases.
- [x] I have ensured my changes compile on macOS & iOS.
- [x] I have resolved all SwiftLint warnings.
