### PR TITLE
Universal Links

### DIFF
--- a/CanvasPlusPlayground.xcodeproj/project.pbxproj
+++ b/CanvasPlusPlayground.xcodeproj/project.pbxproj
@@ -146,6 +146,7 @@
 		B75684F42DA5A6B2003B4A32 /* HTMLView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B75684F32DA5A6B2003B4A32 /* HTMLView.swift */; };
 		B75684F62DA5A7D3003B4A32 /* CanvasURLService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B75684F52DA5A7CE003B4A32 /* CanvasURLService.swift */; };
 		B75684F82DA5F9F4003B4A32 /* GetSinglePageRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B75684F72DA5F9F4003B4A32 /* GetSinglePageRequest.swift */; };
+		B75684FA2DA7A080003B4A32 /* GetSingleDiscussionTopicRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B75684F92DA7A080003B4A32 /* GetSingleDiscussionTopicRequest.swift */; };
 		B76454FE2C8DF61B002DF00E /* Course.swift in Sources */ = {isa = PBXBuildFile; fileRef = B76454ED2C8DF61B002DF00E /* Course.swift */; };
 		B76454FF2C8DF61B002DF00E /* Enrollment.swift in Sources */ = {isa = PBXBuildFile; fileRef = B76454EE2C8DF61B002DF00E /* Enrollment.swift */; };
 		B76455002C8DF61B002DF00E /* File.swift in Sources */ = {isa = PBXBuildFile; fileRef = B76454EF2C8DF61B002DF00E /* File.swift */; };
@@ -359,6 +360,7 @@
 		B75684F32DA5A6B2003B4A32 /* HTMLView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTMLView.swift; sourceTree = "<group>"; };
 		B75684F52DA5A7CE003B4A32 /* CanvasURLService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanvasURLService.swift; sourceTree = "<group>"; };
 		B75684F72DA5F9F4003B4A32 /* GetSinglePageRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetSinglePageRequest.swift; sourceTree = "<group>"; };
+		B75684F92DA7A080003B4A32 /* GetSingleDiscussionTopicRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetSingleDiscussionTopicRequest.swift; sourceTree = "<group>"; };
 		B76454642C8BBC7F002DF00E /* CanvasPlusPlayground.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CanvasPlusPlayground.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B76454ED2C8DF61B002DF00E /* Course.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Course.swift; sourceTree = "<group>"; };
 		B76454EE2C8DF61B002DF00E /* Enrollment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Enrollment.swift; sourceTree = "<group>"; };
@@ -494,6 +496,7 @@
 				A301EE082D61137400D71139 /* MarkCourseDiscussionTopicReadRequest.swift */,
 				A301EE0A2D61148C00D71139 /* MarkCourseDiscussionTopicUnreadRequest.swift */,
 				A301EE122D614A4100D71139 /* GetDiscussionTopicsRequest.swift */,
+				B75684F92DA7A080003B4A32 /* GetSingleDiscussionTopicRequest.swift */,
 				A372D1092D90DA7A005E94CA /* GetCourseGroupsRequest.swift */,
 				A33BE8742D97A6F7005C1D13 /* GetGroupMembershipRequest.swift */,
 				A37AB4A62D98670600610639 /* LeaveGroupRequest.swift */,
@@ -1224,6 +1227,7 @@
 				A3049B752D15DC1C002F3166 /* GetCoursesRequest.swift in Sources */,
 				B76455042C8DF61B002DF00E /* CourseView.swift in Sources */,
 				A372D1042D90BEB4005E94CA /* CanvasGroup.swift in Sources */,
+				B75684FA2DA7A080003B4A32 /* GetSingleDiscussionTopicRequest.swift in Sources */,
 				A3049B682D0F3ECA002F3166 /* QuizzesViewModel.swift in Sources */,
 				A3CF88D12D18E61B000ACDF3 /* APIResponse.swift in Sources */,
 				A373DC352D2824D700215019 /* Module.swift in Sources */,

--- a/CanvasPlusPlayground.xcodeproj/project.pbxproj
+++ b/CanvasPlusPlayground.xcodeproj/project.pbxproj
@@ -143,6 +143,9 @@
 		B7460A942D6BFB1A0069CF5B /* GradeCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7460A932D6BFB1A0069CF5B /* GradeCalculator.swift */; };
 		B7460A962D6CCD730069CF5B /* GradeCalculatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7460A952D6CCD6E0069CF5B /* GradeCalculatorView.swift */; };
 		B74688A32D63DB59007A27FD /* Assignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = B74688A22D63DB59007A27FD /* Assignment.swift */; };
+		B75684F42DA5A6B2003B4A32 /* HTMLView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B75684F32DA5A6B2003B4A32 /* HTMLView.swift */; };
+		B75684F62DA5A7D3003B4A32 /* CanvasURLService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B75684F52DA5A7CE003B4A32 /* CanvasURLService.swift */; };
+		B75684F82DA5F9F4003B4A32 /* GetSinglePageRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B75684F72DA5F9F4003B4A32 /* GetSinglePageRequest.swift */; };
 		B76454FE2C8DF61B002DF00E /* Course.swift in Sources */ = {isa = PBXBuildFile; fileRef = B76454ED2C8DF61B002DF00E /* Course.swift */; };
 		B76454FF2C8DF61B002DF00E /* Enrollment.swift in Sources */ = {isa = PBXBuildFile; fileRef = B76454EE2C8DF61B002DF00E /* Enrollment.swift */; };
 		B76455002C8DF61B002DF00E /* File.swift in Sources */ = {isa = PBXBuildFile; fileRef = B76454EF2C8DF61B002DF00E /* File.swift */; };
@@ -353,6 +356,9 @@
 		B7460A932D6BFB1A0069CF5B /* GradeCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GradeCalculator.swift; sourceTree = "<group>"; };
 		B7460A952D6CCD6E0069CF5B /* GradeCalculatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GradeCalculatorView.swift; sourceTree = "<group>"; };
 		B74688A22D63DB59007A27FD /* Assignment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Assignment.swift; sourceTree = "<group>"; };
+		B75684F32DA5A6B2003B4A32 /* HTMLView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTMLView.swift; sourceTree = "<group>"; };
+		B75684F52DA5A7CE003B4A32 /* CanvasURLService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanvasURLService.swift; sourceTree = "<group>"; };
+		B75684F72DA5F9F4003B4A32 /* GetSinglePageRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetSinglePageRequest.swift; sourceTree = "<group>"; };
 		B76454642C8BBC7F002DF00E /* CanvasPlusPlayground.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CanvasPlusPlayground.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B76454ED2C8DF61B002DF00E /* Course.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Course.swift; sourceTree = "<group>"; };
 		B76454EE2C8DF61B002DF00E /* Enrollment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Enrollment.swift; sourceTree = "<group>"; };
@@ -479,6 +485,7 @@
 				A3049B842D161455002F3166 /* GetEnrollmentsRequest.swift */,
 				A3049B862D16146D002F3166 /* GetQuizzesRequest.swift */,
 				A3D1614E2D1784E3004055FB /* GetUserRequest.swift */,
+				B75684F72DA5F9F4003B4A32 /* GetSinglePageRequest.swift */,
 				A3D0225C2D6A711900F8068C /* GetPagesRequest.swift */,
 				A3D161502D178615004055FB /* GetUserProfileRequest.swift */,
 				A373DC2C2D28172E00215019 /* GetModulesRequest.swift */,
@@ -582,6 +589,7 @@
 		A324BA552D0796BE005F53FA /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
+				B75684F52DA5A7CE003B4A32 /* CanvasURLService.swift */,
 				B7CC4D5B2D90C00800254F55 /* CGSize+Center.swift */,
 				B7CC4D3B2D8DB86E00254F55 /* URL+AppRootURL.swift */,
 				9B07E7112D779CA500359B69 /* Date+RelativeDates.swift */,
@@ -607,6 +615,7 @@
 				B7CC4D5D2D90C03C00254F55 /* Intelligence */,
 				B7CC4D442D8DFF1500254F55 /* PickerService */,
 				B7C0A3C82D2F87E9003E5A36 /* AsyncView.swift */,
+				B75684F32DA5A6B2003B4A32 /* HTMLView.swift */,
 				B7F950332D11A00F004BB470 /* StatusToolbarItem.swift */,
 				9A977E8A2D6C375E001D7F0A /* ColorPickerSheet.swift */,
 				3DAE84FF2C9A0E4F008C22E7 /* BridgedPDFView.swift */,
@@ -1281,6 +1290,7 @@
 				A35191412D283589001E415F /* ModulesViewModel.swift in Sources */,
 				A3E7F3912C99317100DC4300 /* CourseTabsManager.swift in Sources */,
 				A372D0FF2D90BAB6005E94CA /* CourseGroupsView.swift in Sources */,
+				B75684F82DA5F9F4003B4A32 /* GetSinglePageRequest.swift in Sources */,
 				B7CC4D672D91AF4300254F55 /* GetUserTodoItemsRequest.swift in Sources */,
 				9B6D4F802D6E48340033044F /* ReminderButton.swift in Sources */,
 				A3E7F38F2C96C1CE00DC4300 /* CourseTabsView.swift in Sources */,
@@ -1318,6 +1328,7 @@
 				B7C0A3C72D2F4E82003E5A36 /* GetFileRequest.swift in Sources */,
 				A31A81E72D0CCB69003C37EB /* GradesViewModel.swift in Sources */,
 				A373DC142D19FA2A00215019 /* APICourseSection.swift in Sources */,
+				B75684F62DA5A7D3003B4A32 /* CanvasURLService.swift in Sources */,
 				A3E7F38B2C9555B200DC4300 /* CanvasService.swift in Sources */,
 				B72EA5702D5689B20013070E /* QuickLookPreview.swift in Sources */,
 				A372D10E2D90F505005E94CA /* CourseGroupsViewModel.swift in Sources */,
@@ -1333,6 +1344,7 @@
 				B7CC4D432D8DFF0A00254F55 /* PickerServiceViewModifier.swift in Sources */,
 				B73AE0BD2D4FB68B007094A8 /* Profile.swift in Sources */,
 				B7AD550C2CD4257B00FB09BB /* IntelligenceOnboardingView.swift in Sources */,
+				B75684F42DA5A6B2003B4A32 /* HTMLView.swift in Sources */,
 				B7D751312D3D688C00F7B8B8 /* AnnouncementRow.swift in Sources */,
 				A372D1102D91D1A1005E94CA /* GroupDetailView.swift in Sources */,
 				A3049B792D15E162002F3166 /* GetCourseRootFolderRequest.swift in Sources */,

--- a/CanvasPlusPlayground/Common/Components/HTMLView.swift
+++ b/CanvasPlusPlayground/Common/Components/HTMLView.swift
@@ -71,7 +71,7 @@ struct HTMLView: ViewRepresentable {
                         await onDestinationLink(potentialDestination)
                     } else {
                         #if os(iOS)
-                        UIApplication.shared.open(url)
+                        await UIApplication.shared.open(url)
                         #else
                         NSWorkspace.shared.open(url)
                         #endif

--- a/CanvasPlusPlayground/Common/Components/HTMLView.swift
+++ b/CanvasPlusPlayground/Common/Components/HTMLView.swift
@@ -1,0 +1,93 @@
+//
+//  HTMLView.swift
+//  CanvasPlusPlayground
+//
+//  Created by Rahul on 4/8/25.
+//
+
+import SwiftUI
+@preconcurrency import WebKit
+#if os(iOS)
+import UIKit
+#else
+import AppKit
+#endif
+
+struct HTMLView: ViewRepresentable {
+    @Environment(NavigationModel.self) private var navigationModel
+
+    let html: String
+    let courseID: Course.ID?
+
+    #if os(iOS)
+    func makeUIView(context: Context) -> WKWebView {
+        makeView(context: context)
+    }
+    #else
+    func makeNSView(context: Context) -> WKWebView {
+        makeView(context: context)
+    }
+    #endif
+
+    #if os(iOS)
+    func updateUIView(_ uiView: WKWebView, context: Context) {
+        updateView(uiView, context: context)
+    }
+    #else
+    func updateNSView(_ nsView: WKWebView, context: Context) {
+        updateView(nsView, context: context)
+    }
+    #endif
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator {
+            await navigationModel.handleURLSelection(result: $0, courseID: courseID)
+        }
+    }
+
+    func makeView(context: Context) -> WKWebView {
+        let webView = WKWebView()
+        webView.navigationDelegate = context.coordinator
+        return webView
+    }
+
+    func updateView(_ view: WKWebView, context: Context) {
+        view.loadHTMLString(html, baseURL: nil)
+    }
+
+    class Coordinator: NSObject, WKNavigationDelegate {
+        let onDestinationLink: (CanvasURLService.URLServiceResult) async -> Void
+
+        init(onDestinationLink: @escaping (CanvasURLService.URLServiceResult) async -> Void) {
+            self.onDestinationLink = onDestinationLink
+        }
+
+        func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction) async -> WKNavigationActionPolicy {
+            if navigationAction.navigationType == .linkActivated {
+                if let url = navigationAction.request.url {
+                    if let potentialDestination = CanvasURLService.determineNavigationDestination(
+                        from: url
+                    ) {
+                        await onDestinationLink(potentialDestination)
+                    } else {
+                        #if os(iOS)
+                        UIApplication.shared.open(url)
+                        #else
+                        NSWorkspace.shared.open(url)
+                        #endif
+                    }
+
+                    return .cancel
+                }
+            }
+
+            return .allow
+        }
+    }
+}
+
+#if os(iOS)
+typealias ViewRepresentable = UIViewRepresentable
+#else
+typealias ViewRepresentable = NSViewRepresentable
+#endif

--- a/CanvasPlusPlayground/Common/Network/API Requests/GetSingleDiscussionTopicRequest.swift
+++ b/CanvasPlusPlayground/Common/Network/API Requests/GetSingleDiscussionTopicRequest.swift
@@ -1,0 +1,44 @@
+//
+//  GetSingleDiscussionTopicRequest.swift
+//  CanvasPlusPlayground
+//
+//  Created by Rahul on 4/10/25.
+//
+
+import Foundation
+
+struct GetSingleDiscussionTopicRequest: CacheableArrayAPIRequest {
+    typealias Subject = DiscussionTopicAPI
+
+    let courseId: String
+    let topicId: String
+
+    var path: String { "courses/\(courseId)/discussion_topics/\(topicId)" }
+
+    var queryParameters: [QueryParameter] {
+        include.map { ("include[]", $0.rawValue) }
+    }
+
+    let include: [Include]
+
+    var requestId: String { topicId }
+
+    var requestIdKey: ParentKeyPath<DiscussionTopic, String> {
+        .createReadable(\.id)
+    }
+
+    var idPredicate: Predicate<DiscussionTopic> {
+        #Predicate {
+            $0.id == topicId
+        }
+    }
+    var customPredicate: Predicate<DiscussionTopic> {
+        .true
+    }
+}
+
+extension GetSingleDiscussionTopicRequest {
+    enum Include: String {
+        case allDates = "all_dates", sections, sectionsUserCount = "sections_user_count", overrides
+    }
+}

--- a/CanvasPlusPlayground/Common/Network/API Requests/GetSinglePageRequest.swift
+++ b/CanvasPlusPlayground/Common/Network/API Requests/GetSinglePageRequest.swift
@@ -1,0 +1,41 @@
+//
+//  GetSinglePageRequest.swift
+//  CanvasPlusPlayground
+//
+//  Created by Rahul on 4/8/25.
+//
+
+import Foundation
+
+struct GetSinglePageRequest: CacheableAPIRequest {
+    typealias Subject = PageAPI
+
+    let courseId: String
+    /// In most cases, this is the `url` parameter of the `Page`.
+    let pageURL: String
+
+    var path: String { "courses/\(courseId)/pages/\(pageURL)" }
+
+    var queryParameters: [QueryParameter] {
+        []
+    }
+
+    init(
+        courseId: String,
+        pageURL: String
+    ) {
+        self.courseId = courseId
+        self.pageURL = pageURL
+    }
+
+    var requestId: String { pageURL }
+    var requestIdKey: ParentKeyPath<Page, String> { .createReadable(\.url) }
+
+    var idPredicate: Predicate<Page> {
+        #Predicate<Page> { page in
+            page.url == pageURL
+        }
+    }
+
+    var customPredicate: Predicate<Page> { .true }
+}

--- a/CanvasPlusPlayground/Common/Network/CanvasRequest.swift
+++ b/CanvasPlusPlayground/Common/Network/CanvasRequest.swift
@@ -212,6 +212,18 @@ enum CanvasRequest {
         )
     }
 
+    static func getSingleDiscussionTopic(
+        courseId: String,
+        topicId: String,
+        include: [GetSingleDiscussionTopicRequest.Include] = []
+    ) -> GetSingleDiscussionTopicRequest {
+        GetSingleDiscussionTopicRequest(
+            courseId: courseId,
+            topicId: topicId,
+            include: include
+        )
+    }
+
     static func getDiscussionTopics(
         courseId: String,
         include: [GetDiscussionTopicsRequest.Include] = [],

--- a/CanvasPlusPlayground/Common/Network/CanvasRequest.swift
+++ b/CanvasPlusPlayground/Common/Network/CanvasRequest.swift
@@ -270,6 +270,16 @@ enum CanvasRequest {
         )
     }
 
+    static func getSinglePage(
+        courseId: String,
+        pageURL: String
+    ) -> GetSinglePageRequest {
+        GetSinglePageRequest(
+            courseId: courseId,
+            pageURL: pageURL
+        )
+    }
+
     static func getPages(
         courseId: String,
         perPage: Int = 50

--- a/CanvasPlusPlayground/Common/Utilities/CanvasURLService.swift
+++ b/CanvasPlusPlayground/Common/Utilities/CanvasURLService.swift
@@ -1,0 +1,98 @@
+//
+//  CanvasURLService.swift
+//  CanvasPlusPlayground
+//
+//  Created by Rahul on 4/8/25.
+//
+
+import Foundation
+
+enum CanvasURLService {
+    enum URLServiceResult {
+        case announcement(DiscussionTopic.ID)
+        case assignment(Assignment.ID)
+        case file(File.ID)
+        case page(Page.ID)
+    }
+
+    static func determineNavigationDestination(from url: URL) -> URLServiceResult? {
+        let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        // Example URL: "https://gatech.instructure.com/courses/447818/assignments/2053294"
+
+        // Break down URL into ["courses", courseID, type, objectID]
+
+        guard let path = components?.path else { return nil }
+        let pathComponents = path.components(separatedBy: "/").filter { !$0.isEmpty }
+
+        guard pathComponents.count >= 3 else { return nil }
+
+        let type = pathComponents[2] // (assignments, files, etc)
+
+        guard pathComponents.count >= 4 else { return nil }
+
+        let id = pathComponents[3]
+
+        switch type {
+        case "assignments":
+            return .assignment(id)
+        case "discussion_topics", "announcements":
+            return .announcement(id)
+        case "pages":
+            print(url)
+            return .page(id)
+        case "files":
+            // TODO: Support Files
+            return nil
+        default:
+            return nil
+        }
+    }
+}
+
+extension NavigationModel {
+    func handleURLSelection(result: CanvasURLService.URLServiceResult, courseID: Course.ID?) async {
+        guard let courseID else { return }
+
+        guard let destination = await Self.Destination.destination(
+            from: result,
+            for: courseID
+        ) else { return }
+
+        navigationPath.append(destination)
+    }
+}
+
+extension NavigationModel.Destination {
+    static func destination(from urlServiceResult: CanvasURLService.URLServiceResult, for courseID: Course.ID) async -> Self? {
+        switch urlServiceResult {
+        case .announcement(let id):
+            let announcements = try? await CanvasService.shared.loadAndSync(
+                CanvasRequest.getDiscussionTopics(courseId: courseID)
+            )
+
+            guard let announcement = announcements?.first(where: { $0.id == id }) else { return nil }
+            return .announcement(announcement)
+        case .assignment(let id):
+            let assignments = try? await CanvasService.shared.loadAndSync(
+                CanvasRequest.getAssignment(id: id, courseId: courseID)
+            )
+
+            guard let assignment = assignments?.first else { return nil }
+
+            return .assignment(assignment)
+        case .page(let id):
+            let pages = try? await CanvasService.shared.loadAndSync(
+                CanvasRequest.getSinglePage(courseId: courseID, pageURL: id)
+            )
+
+            guard let page = pages?.first else {
+                return nil
+            }
+
+            return .page(page)
+        case .file:
+            // TODO: Support Files
+            return nil
+        }
+    }
+}

--- a/CanvasPlusPlayground/Features/Announcements/CourseAnnouncementDetailView.swift
+++ b/CanvasPlusPlayground/Features/Announcements/CourseAnnouncementDetailView.swift
@@ -8,8 +8,6 @@
 import SwiftUI
 
 struct CourseAnnouncementDetailView: View {
-    @Environment(NavigationModel.self) private var navigationModel
-
     let announcement: DiscussionTopic
 
     var body: some View {

--- a/CanvasPlusPlayground/Features/Announcements/CourseAnnouncementDetailView.swift
+++ b/CanvasPlusPlayground/Features/Announcements/CourseAnnouncementDetailView.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct CourseAnnouncementDetailView: View {
+    @Environment(NavigationModel.self) private var navigationModel
+
     let announcement: DiscussionTopic
 
     var body: some View {

--- a/CanvasPlusPlayground/Features/Announcements/Models/DiscussionTopic.swift
+++ b/CanvasPlusPlayground/Features/Announcements/Models/DiscussionTopic.swift
@@ -11,6 +11,8 @@ import SwiftData
 // swiftlint:disable commented_code
 @Model
 class DiscussionTopic: Cacheable, Hashable, Equatable {
+    typealias ID = String
+
     var id: String
 
     // MARK: In Docs

--- a/CanvasPlusPlayground/Features/Assignments/Models/Assignment.swift
+++ b/CanvasPlusPlayground/Features/Assignments/Models/Assignment.swift
@@ -10,6 +10,7 @@ import SwiftData
 
 @Model
 class Assignment: Cacheable {
+    typealias ID = String
     typealias ServerID = Int
 
     @Attribute(.unique) let id: String

--- a/CanvasPlusPlayground/Features/Courses/CourseView.swift
+++ b/CanvasPlusPlayground/Features/Courses/CourseView.swift
@@ -68,6 +68,21 @@ struct CourseView: View {
         .navigationDestination(for: NavigationModel.Destination.self) { destination in
             destination.destinationView()
                 .environment(tabsManager)
+                .environment(\.openURL, OpenURLAction { url in
+                    guard let urlServiceResult = CanvasURLService.determineNavigationDestination(
+                        from: url
+                    ) else { return .discarded }
+
+                    Task {
+                        await navigationModel
+                            .handleURLSelection(
+                                result: urlServiceResult,
+                                courseID: course.id
+                            )
+                    }
+
+                    return .handled
+                })
         }
         .disabled(isLoadingTabs)
     }

--- a/CanvasPlusPlayground/Features/Courses/CourseView.swift
+++ b/CanvasPlusPlayground/Features/Courses/CourseView.swift
@@ -47,7 +47,7 @@ struct CourseView: View {
         @Bindable var navigationModel = navigationModel
 
         List(coursePages, id: \.self, selection: $navigationModel.selectedCoursePage) { page in
-            NavigationLink(value: NavigationModel.Destination.coursePage(page)) {
+            NavigationLink(value: NavigationModel.Destination.coursePage(page, course)) {
                 Label(page.title, systemImage: page.systemImageIcon)
             }
             .tag(page)
@@ -66,7 +66,7 @@ struct CourseView: View {
         .tint(course.rgbColors?.color)
         .navigationTitle(course.displayName)
         .navigationDestination(for: NavigationModel.Destination.self) { destination in
-            destination.destinationView(for: course)
+            destination.destinationView()
                 .environment(tabsManager)
         }
         .disabled(isLoadingTabs)

--- a/CanvasPlusPlayground/Features/Files/Models/File.swift
+++ b/CanvasPlusPlayground/Features/Files/Models/File.swift
@@ -48,6 +48,7 @@ import SwiftData
 
 @Model
 class File: Cacheable {
+    typealias ID = String
     typealias ServerID = Int
 
     // MARK: - Attributes

--- a/CanvasPlusPlayground/Features/Navigation/HomeView.swift
+++ b/CanvasPlusPlayground/Features/Navigation/HomeView.swift
@@ -118,7 +118,7 @@ struct HomeView: View {
                     }
                 }
                 .navigationDestination(for: NavigationModel.Destination.self) { destination in
-                    destination.destinationView(for: selectedCourse)
+                    destination.destinationView()
                 }
             } else {
                 ContentUnavailableView("Select a course", systemImage: "folder")

--- a/CanvasPlusPlayground/Features/Navigation/NavigationModel.swift
+++ b/CanvasPlusPlayground/Features/Navigation/NavigationModel.swift
@@ -98,7 +98,7 @@ class NavigationModel {
 
     enum Destination: Hashable {
         case course(Course)
-        case coursePage(CoursePage)
+        case coursePage(CoursePage, Course)
 
         case announcement(DiscussionTopic)
         case assignment(Assignment)
@@ -106,14 +106,12 @@ class NavigationModel {
         // TODO: Add specific course items as needed.
 
         @ViewBuilder
-        func destinationView(for course: Course?) -> some View {
+        func destinationView() -> some View {
             switch self {
             case .course(let course):
                 CourseView(course: course)
-            case .coursePage(let coursePage):
-                if let course {
-                    CourseDetailView(course: course, coursePage: coursePage)
-                }
+            case .coursePage(let coursePage, let course):
+                CourseDetailView(course: course, coursePage: coursePage)
             case .announcement(let announcement):
                 CourseAnnouncementDetailView(announcement: announcement)
             case .assignment(let assignment):

--- a/CanvasPlusPlayground/Features/Pages/PageView.swift
+++ b/CanvasPlusPlayground/Features/Pages/PageView.swift
@@ -6,7 +6,6 @@
 //
 
 import SwiftUI
-import WebKit
 
 struct PageView: View {
     let page: Page
@@ -14,7 +13,7 @@ struct PageView: View {
     var body: some View {
         ZStack {
             if let htmlContent = page.body, !htmlContent.isEmpty {
-                HTMLView(html: htmlContent)
+                HTMLView(html: htmlContent, courseID: page.courseID)
             } else {
                 ContentUnavailableView("No pages available", systemImage: "exclamationmark.bubble.fill")
             }
@@ -22,34 +21,3 @@ struct PageView: View {
         .navigationTitle(page.title ?? "Untitled")
     }
 }
-
-#if os(iOS)
-import UIKit
-
-struct HTMLView: UIViewRepresentable {
-    let html: String
-
-    func makeUIView(context: Context) -> WKWebView {
-        WKWebView()
-    }
-
-    func updateUIView(_ uiView: WKWebView, context: Context) {
-        uiView.loadHTMLString(html, baseURL: nil)
-    }
-}
-
-#elseif os(macOS)
-import AppKit
-
-struct HTMLView: NSViewRepresentable {
-    let html: String
-
-    func makeNSView(context: Context) -> WKWebView {
-        WKWebView()
-    }
-
-    func updateNSView(_ nsView: WKWebView, context: Context) {
-        nsView.loadHTMLString(html, baseURL: nil)
-    }
-}
-#endif


### PR DESCRIPTION
Fixes #237

## Changes Made

- Implement a `CanvasURLService` which parses a URL, extracting a specific course item type and its ID.
- Use this in `HTMLView` (Pages) and, through the `openURL` environment, in `HTMLTextView` (announcements/assignments)
- Eventually use this same logic for #289.

## Screenshots (if applicable)

## Checklist
- [x] I have implemented all requirements for this PR and its accompanying issue.
- [x] I have verified my implementation across all edge cases.
- [x] I have ensured my changes compile on macOS & iOS.
- [x] I have resolved all SwiftLint warnings.
