### PR TITLE
HOTFIX assignment submissions drag-and-drop

### DIFF
--- a/CanvasPlusPlayground/Features/Assignments/AssignmentSubmissionView.swift
+++ b/CanvasPlusPlayground/Features/Assignments/AssignmentSubmissionView.swift
@@ -213,7 +213,9 @@ struct AssignmentSubmissionView: View {
                             showErrorAlert.wrappedValue = true
                             return
                         }
-                        if allowedFileTypes.contains(type) {
+                        if allowedFileTypes.contains(where: { allowedType in
+                            type.conforms(to: allowedType)
+                        }) {
                             selectedURLs.append(url)
                         } else {
                             error = AssignmentSubmissionError.invalidFileType


### PR DESCRIPTION
Fixes #<issue number, e.g. #100>

## Changes Made

- Fixed bug where assignments with * file uploads would not accept files via drag-drop
- ...
- ...

## Screenshots (if applicable)

## Checklist
- [ ] I have implemented all requirements for this PR and its accompanying issue.
- [ ] I have verified my implementation across all edge cases.
- [ ] I have ensured my changes compile on macOS & iOS.
- [ ] I have resolved all SwiftLint warnings.
