### PR TITLE
Use favorites in getCourseRequest

### DIFF
--- a/CanvasPlusPlayground/Common/Network/CanvasRequest.swift
+++ b/CanvasPlusPlayground/Common/Network/CanvasRequest.swift
@@ -13,8 +13,8 @@ enum CanvasRequest {
         GetCoursesRequest(enrollmentState: enrollmentState, perPage: perPage)
     }
 
-    static func getCourse(id: String) -> GetCourseRequest {
-        GetCourseRequest(courseId: id)
+    static func getCourse(id: String, include: [GetCourseRequest.Include] = [.favorites]) -> GetCourseRequest {
+        GetCourseRequest(courseId: id, include: include)
     }
 
     static func getToDoItems(


### PR DESCRIPTION
Fixes --

## Issue

When loading Pinned Items, favorited courses may disappear. This is because the new course object fetched does not include the favorites property.

https://github.com/user-attachments/assets/2e910210-03cc-45fe-847b-ad09a7c1afb6

## Changes Made

- Include the favorites property when fetching a singular course

## Screenshots (if applicable)

https://github.com/user-attachments/assets/0b5b40d3-2e41-4947-be0a-8c5ae6635927

## Checklist
- [x] I have implemented all requirements for this PR and its accompanying issue.
- [x] I have verified my implementation across all edge cases.
- [x] I have ensured my changes compile on macOS & iOS.
- [x] I have resolved all SwiftLint warnings.
