### PR TITLE
Fix Course Fetching

### DIFF
--- a/CanvasPlusPlayground/Features/Courses/Models/CourseAPI.swift
+++ b/CanvasPlusPlayground/Features/Courses/Models/CourseAPI.swift
@@ -115,13 +115,6 @@ struct CourseProgress: Codable {
     let requirementCompletedCount: Int?
     let nextRequirementUrl: URL?
     let completedAt: Date?
-
-    enum CodingKeys: String, CodingKey {
-        case requirementCount = "requirement_count"
-        case requirementCompletedCount = "requirement_completed_count"
-        case nextRequirementUrl = "next_requirement_url"
-        case completedAt = "completed_at"
-    }
 }
 
 struct CourseSectionRef: Codable {
@@ -182,16 +175,6 @@ struct CourseTerm: Codable {
     let createdAt: Date?
     let workflowState: WorkflowState?
     let gradingPeriodGroupId: Int?
-
-    enum CodingKeys: String, CodingKey {
-        case id
-        case name
-        case startAt = "start_at"
-        case endAt = "end_at"
-        case createdAt = "created_at"
-        case workflowState = "workflow_state"
-        case gradingPeriodGroupId = "grading_period_group_id"
-    }
 
     enum WorkflowState: String, Codable {
         case active, deleted


### PR DESCRIPTION
Fixes --

## Changes Made

- There was an error regarding decoding `CourseTerm` and a few other sub types in `CourseAPI`. The coding keys were not being decoded correctly when the API response was converted to the model, so we should ignore the coding keys. This seems to be a change in the 26.0 SDK. If possible, it would be nice to verify on previous versions.

## Screenshots (if applicable)

## Checklist
- [x] I have implemented all requirements for this PR and its accompanying issue.
- [x] I have verified my implementation across all edge cases.
- [x] I have ensured my changes compile on macOS & iOS.
- [x] I have resolved all SwiftLint warnings.
