### PR TITLE
Steven multiple windows

### DIFF
--- a/CanvasPlusPlayground.xcodeproj/project.pbxproj
+++ b/CanvasPlusPlayground.xcodeproj/project.pbxproj
@@ -10,6 +10,9 @@
 		192EC0482C963ACB00AF8528 /* CourseAssignmentManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 192EC0472C963ACB00AF8528 /* CourseAssignmentManager.swift */; };
 		192EC04A2C963B9000AF8528 /* AssignmentAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 192EC0492C963B9000AF8528 /* AssignmentAPI.swift */; };
 		192EC04C2C963EE600AF8528 /* CourseAssignmentsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 192EC04B2C963EE600AF8528 /* CourseAssignmentsView.swift */; };
+		267D85262E662019007F821B /* CourseContextMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 267D85252E662009007F821B /* CourseContextMenu.swift */; };
+		267D85282E662AC5007F821B /* FocusWindowInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 267D85272E662AB0007F821B /* FocusWindowInfo.swift */; };
+		267D852A2E6644FE007F821B /* FocusWindowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 267D85292E6644FE007F821B /* FocusWindowView.swift */; };
 		3DAE85002C9A0E4F008C22E7 /* BridgedPDFView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DAE84FF2C9A0E4F008C22E7 /* BridgedPDFView.swift */; };
 		7F8535742C98DE3C0023E384 /* CourseGradeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F8535732C98DE3C0023E384 /* CourseGradeView.swift */; };
 		95BA93482C9CE20D00137A91 /* CalendarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95BA93472C9CE20D00137A91 /* CalendarView.swift */; };
@@ -230,6 +233,9 @@
 		192EC0472C963ACB00AF8528 /* CourseAssignmentManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseAssignmentManager.swift; sourceTree = "<group>"; };
 		192EC0492C963B9000AF8528 /* AssignmentAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssignmentAPI.swift; sourceTree = "<group>"; };
 		192EC04B2C963EE600AF8528 /* CourseAssignmentsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseAssignmentsView.swift; sourceTree = "<group>"; };
+		267D85252E662009007F821B /* CourseContextMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseContextMenu.swift; sourceTree = "<group>"; };
+		267D85272E662AB0007F821B /* FocusWindowInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusWindowInfo.swift; sourceTree = "<group>"; };
+		267D85292E6644FE007F821B /* FocusWindowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusWindowView.swift; sourceTree = "<group>"; };
 		3DAE84FF2C9A0E4F008C22E7 /* BridgedPDFView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BridgedPDFView.swift; sourceTree = "<group>"; };
 		7F8535732C98DE3C0023E384 /* CourseGradeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseGradeView.swift; sourceTree = "<group>"; };
 		95BA93472C9CE20D00137A91 /* CalendarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarView.swift; sourceTree = "<group>"; };
@@ -1053,6 +1059,8 @@
 		B7E59A0E2D200281001836FE /* Navigation */ = {
 			isa = PBXGroup;
 			children = (
+				267D85272E662AB0007F821B /* FocusWindowInfo.swift */,
+				267D85252E662009007F821B /* CourseContextMenu.swift */,
 				B7A26EE82CCB62A00084704A /* NavigationModel.swift */,
 				B76454F52C8DF61B002DF00E /* HomeView.swift */,
 				B7E59A0F2D2002A3001836FE /* Sidebar.swift */,
@@ -1060,6 +1068,7 @@
 				B7E59A132D2004A4001836FE /* CourseListCell.swift */,
 				B7E59A152D20076E001836FE /* CourseDetailView.swift */,
 				9BDFF27D2DA6B6D7009F0DE9 /* OpenInCanvasWebButton.swift */,
+				267D85292E6644FE007F821B /* FocusWindowView.swift */,
 			);
 			path = Navigation;
 			sourceTree = "<group>";
@@ -1282,6 +1291,7 @@
 				A372D10C2D90E875005E94CA /* GroupsListView.swift in Sources */,
 				A3777E0A2DA0E25E00A8B00C /* StorageHandler.swift in Sources */,
 				A3FFD03C2CDED67C006BAB51 /* String+Numbers.swift in Sources */,
+				267D85262E662019007F821B /* CourseContextMenu.swift in Sources */,
 				A301EE132D614A4100D71139 /* GetDiscussionTopicsRequest.swift in Sources */,
 				9A977E832D6C322F001D7F0A /* LoggerService.swift in Sources */,
 				A301EE092D61137400D71139 /* MarkCourseDiscussionTopicReadRequest.swift in Sources */,
@@ -1315,6 +1325,7 @@
 				B7C0A3BF2D2F2251003E5A36 /* PinnedItemsView.swift in Sources */,
 				A3CF88E32D1921CB000ACDF3 /* FolderAPI.swift in Sources */,
 				A373DC2D2D28172E00215019 /* GetModulesRequest.swift in Sources */,
+				267D852A2E6644FE007F821B /* FocusWindowView.swift in Sources */,
 				B7C0A3CD2D3023CA003E5A36 /* PinnedItem.swift in Sources */,
 				B5894F172D6EBEA100E8F527 /* PagesManager.swift in Sources */,
 				B76455072C8DF61B002DF00E /* CourseFileViewModel.swift in Sources */,
@@ -1352,6 +1363,7 @@
 				A3D161512D178615004055FB /* GetUserProfileRequest.swift in Sources */,
 				A3D161492D169C23004055FB /* CacheableAPIRequest+Storage.swift in Sources */,
 				9B6663E32C9853BC0060990E /* HTMLTextView.swift in Sources */,
+				267D85282E662AC5007F821B /* FocusWindowInfo.swift in Sources */,
 				B7CC4D432D8DFF0A00254F55 /* PickerServiceViewModifier.swift in Sources */,
 				B73AE0BD2D4FB68B007094A8 /* Profile.swift in Sources */,
 				B75684F42DA5A6B2003B4A32 /* HTMLView.swift in Sources */,

--- a/CanvasPlusPlayground.xcodeproj/project.pbxproj
+++ b/CanvasPlusPlayground.xcodeproj/project.pbxproj
@@ -1083,7 +1083,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = B76454722C8BBC81002DF00E /* Build configuration list for PBXNativeTarget "CanvasPlusPlayground" */;
 			buildPhases = (
-                9ACDA5E82D5F1DA2001F1F0A /* SwiftLint */,
 				B76454602C8BBC7F002DF00E /* Sources */,
 				B76454612C8BBC7F002DF00E /* Frameworks */,
 				B76454622C8BBC7F002DF00E /* Resources */,
@@ -1503,7 +1502,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"CanvasPlusPlayground/Preview Content\"";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 9A6KR832BZ;
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1521,7 +1520,7 @@
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.4;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.gtiosclub.CanvasPlus;
+				PRODUCT_BUNDLE_IDENTIFIER = com.gtiosclub.stevenliu.CanvasPlus;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = NO;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
@@ -1544,7 +1543,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"CanvasPlusPlayground/Preview Content\"";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 9A6KR832BZ;
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1562,7 +1561,7 @@
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.4;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.gtiosclub.CanvasPlus;
+				PRODUCT_BUNDLE_IDENTIFIER = com.gtiosclub.stevenliu.CanvasPlus;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = NO;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";

--- a/CanvasPlusPlayground/CanvasPlusPlaygroundApp.swift
+++ b/CanvasPlusPlayground/CanvasPlusPlaygroundApp.swift
@@ -22,9 +22,10 @@ struct CanvasPlusPlaygroundApp: App {
     @State private var courseManager = CourseManager()
     @State private var pinnedItemsManager = PinnedItemsManager()
     @State private var remindersManager = RemindersManager()
-
+    
     var body: some Scene {
         WindowGroup {
+            @State var navigationModel = NavigationModel()
             switch launchState {
             case .loading:
                 ProgressView()
@@ -36,8 +37,8 @@ struct CanvasPlusPlaygroundApp: App {
                     .environment(profileManager)
                     .environment(courseManager)
                     .environment(pinnedItemsManager)
-                    .environment(NavigationModel())
                     .environment(remindersManager)
+                    .environment(navigationModel)
                     .onAppear {
                         CanvasService.shared.setupStorage()
                     }
@@ -45,6 +46,19 @@ struct CanvasPlusPlaygroundApp: App {
         }
 
         #if os(macOS)
+        WindowGroup(for: FocusWindowInfo.self) { $focusWindowInfo in
+            @State var navigationModel = NavigationModel()
+            if let focusWindowInfo {
+                FocusWindowView(info: focusWindowInfo)
+                    .environment(listManager)
+                    .environment(profileManager)
+                    .environment(courseManager)
+                    .environment(pinnedItemsManager)
+                    .environment(remindersManager)
+                    .environment(navigationModel)
+            }
+        }
+        
         Settings {
             switch launchState {
             case .loading:

--- a/CanvasPlusPlayground/CanvasPlusPlaygroundApp.swift
+++ b/CanvasPlusPlayground/CanvasPlusPlaygroundApp.swift
@@ -15,8 +15,6 @@ struct CanvasPlusPlaygroundApp: App {
     }
 
     @State var launchState: LaunchState
-    // Navigation
-    @State private var navigationModel = NavigationModel()
 
     // App
     @State private var listManager = ToDoListManager()
@@ -38,7 +36,7 @@ struct CanvasPlusPlaygroundApp: App {
                     .environment(profileManager)
                     .environment(courseManager)
                     .environment(pinnedItemsManager)
-                    .environment(navigationModel)
+                    .environment(NavigationModel())
                     .environment(remindersManager)
                     .onAppear {
                         CanvasService.shared.setupStorage()
@@ -58,7 +56,7 @@ struct CanvasPlusPlaygroundApp: App {
                     .environment(profileManager)
                     .environment(courseManager)
                     .environment(pinnedItemsManager)
-                    .environment(navigationModel)
+                    .environment(NavigationModel())
                     .frame(width: 400, height: 500)
             }
         }

--- a/CanvasPlusPlayground/Features/Courses/CourseView.swift
+++ b/CanvasPlusPlayground/Features/Courses/CourseView.swift
@@ -45,6 +45,7 @@ struct CourseView: View {
         List(coursePages, id: \.self, selection: $navigationModel.selectedCoursePage) { page in
             NavigationLink(value: NavigationModel.Destination.coursePage(page, course)) {
                 Label(page.title, systemImage: page.systemImageIcon)
+                    .contextMenu(for: FocusWindowInfo(courseID: course.id, coursePage: page))
             }
             .tag(page)
         }

--- a/CanvasPlusPlayground/Features/Files/FoldersPageView.swift
+++ b/CanvasPlusPlayground/Features/Files/FoldersPageView.swift
@@ -30,7 +30,6 @@ struct FoldersPageView: View {
         }
     }
     
-    @Environment(NavigationModel.self) private var navigationModel
 
     let course: Course
     @State private var folder: Folder?

--- a/CanvasPlusPlayground/Features/Files/FoldersPageView.swift
+++ b/CanvasPlusPlayground/Features/Files/FoldersPageView.swift
@@ -29,6 +29,8 @@ struct FoldersPageView: View {
             }
         }
     }
+    
+    @Environment(NavigationModel.self) private var navigationModel
 
     let course: Course
     @State private var folder: Folder?

--- a/CanvasPlusPlayground/Features/Navigation/CourseContextMenu.swift
+++ b/CanvasPlusPlayground/Features/Navigation/CourseContextMenu.swift
@@ -1,0 +1,29 @@
+//
+//  CourseContextMenu.swift
+//  CanvasPlusPlayground
+//
+//  Created by Steven Liu on 9/1/25.
+//
+import SwiftUI
+
+struct CourseContextMenu: ViewModifier {
+    @Environment(\.openWindow) private var openWindow
+    
+    let focusWindowInfo: FocusWindowInfo
+    
+    
+    func body(content: Content) -> some View {
+        content
+            .contextMenu {
+                Button("Open in New Window") {
+                    openWindow(value: focusWindowInfo)
+                }
+            }
+    }
+}
+
+extension View {
+    func contextMenu(for focusWindowInfo: FocusWindowInfo) -> some View {
+        modifier(CourseContextMenu(focusWindowInfo: focusWindowInfo))
+    }
+}

--- a/CanvasPlusPlayground/Features/Navigation/FocusWindowInfo.swift
+++ b/CanvasPlusPlayground/Features/Navigation/FocusWindowInfo.swift
@@ -4,8 +4,9 @@
 //
 //  Created by Steven Liu on 9/1/25.
 //
+import Foundation
 
-struct FocusWindowInfo: Codable {
+struct FocusWindowInfo: Codable, Hashable {
     let courseID: Course.ID
     let coursePage: NavigationModel.CoursePage
 }

--- a/CanvasPlusPlayground/Features/Navigation/FocusWindowInfo.swift
+++ b/CanvasPlusPlayground/Features/Navigation/FocusWindowInfo.swift
@@ -1,0 +1,11 @@
+//
+//  Course+Page.swift
+//  CanvasPlusPlayground
+//
+//  Created by Steven Liu on 9/1/25.
+//
+
+struct FocusWindowInfo: Codable {
+    let courseID: Course.ID
+    let coursePage: NavigationModel.CoursePage
+}

--- a/CanvasPlusPlayground/Features/Navigation/FocusWindowView.swift
+++ b/CanvasPlusPlayground/Features/Navigation/FocusWindowView.swift
@@ -8,11 +8,52 @@
 import SwiftUI
 
 struct FocusWindowView: View {
+    
+    @Environment(ToDoListManager.self) private var listManager
+    @Environment(ProfileManager.self) private var profileManager
+    @Environment(CourseManager.self) private var courseManager
+    @Environment(PinnedItemsManager.self) private var pinnedItemsManager
+    @Environment(RemindersManager.self) private var remindersManager
+    @Environment(NavigationModel.self) private var navigationModel
+    
+    let info: FocusWindowInfo
+    
+    private var coursePage: NavigationModel.CoursePage { info.coursePage }
+    
+    private var course: Course? { courseManager.activeCourses.first(where: { $0.id == info.courseID }) }
+    
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        if let course {
+            NavigationStack {
+                Group {
+                    switch coursePage {
+                    case .files:
+                        CourseFilesView(course: course)
+                    case .announcements:
+                        CourseAnnouncementsView(course: course)
+                    case .assignments:
+                        CourseAssignmentsView(course: course)
+                    case .calendar:
+                        CalendarView(course: course)
+                    case .grades:
+                        CourseGradeView(course: course)
+                    case .people:
+                        PeopleView(courseID: course.id)
+                    case .groups:
+                        CourseGroupsView(course: course)
+                    case .quizzes:
+                        CourseQuizzesView(courseId: course.id)
+                    case .modules:
+                        ModulesListView(courseId: course.id)
+                    case .pages:
+                        PagesListView(courseId: course.id)
+                    }
+                }
+            }
+        } else {
+            ContentUnavailableView("Unable to make a focus window", systemImage: "questionmark.square.dashed", description: Text("The course object is nil"))
+        }
     }
 }
 
-#Preview {
-    FocusWindowView()
-}
+

--- a/CanvasPlusPlayground/Features/Navigation/FocusWindowView.swift
+++ b/CanvasPlusPlayground/Features/Navigation/FocusWindowView.swift
@@ -1,0 +1,18 @@
+//
+//  FocusWindowView.swift
+//  CanvasPlusPlayground
+//
+//  Created by Steven Liu on 9/1/25.
+//
+
+import SwiftUI
+
+struct FocusWindowView: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+#Preview {
+    FocusWindowView()
+}

--- a/CanvasPlusPlayground/Features/Navigation/NavigationModel.swift
+++ b/CanvasPlusPlayground/Features/Navigation/NavigationModel.swift
@@ -47,7 +47,7 @@ class NavigationModel {
         }
     }
 
-    enum CoursePage: String, CaseIterable {
+    enum CoursePage: String, CaseIterable, Codable {
         case assignments
         case files
         case announcements
@@ -135,6 +135,7 @@ class NavigationModel {
     var selectedCourseForItemPicker: Course?
     var showAuthorizationSheet = false
     var showProfileSheet = false
+    let windowID = UUID()
     #if os(iOS)
     var showSettingsSheet = false
     #endif


### PR DESCRIPTION
Fixes #321

## Changes Made

- In the CanvasPlusGroundApp: each window instance should have its own `NavigationModel` instance, thus removing the global shared `NavigationModel` instance
- Created a new window group for a newly defined data type `FocusWindowInfo` needed to retain necessary info about which sub-page of which course the user is trying to open a new focus window for
- Created a dedicated custom `CourseContextMenu` view modifier attached to each `NavigationLink` of each course page in CourseView in order to push an instance of data type `FocusWindowInfo`. This view modifier will call `@Environment(\.openWindow)` along with information about the current course and the subpage the user is in in order to create a new instance of the window group for Focus Window.

## Screenshots

https://github.com/user-attachments/assets/70037dd8-ecae-4aa1-968c-085e5706175d



## Checklist
- [x] I have implemented all requirements for this PR and its accompanying issue.
- [x] I have verified my implementation across all edge cases.
- [x] I have ensured my changes compile on macOS & iOS.
- [x] I have resolved all SwiftLint warnings.
