### PR TITLE
fix ios compilation error network debugger

### DIFF
--- a/CanvasPlusPlayground/CanvasPlusPlaygroundApp.swift
+++ b/CanvasPlusPlayground/CanvasPlusPlaygroundApp.swift
@@ -52,7 +52,7 @@ struct CanvasPlusPlaygroundApp: App {
                     }
             }
         }
-        #if DEBUG
+        #if DEBUG && os(macOS)
         .commands {
             CommandMenu("Debug") {
                 Button("Show Network Request Recorder") {
@@ -64,7 +64,7 @@ struct CanvasPlusPlaygroundApp: App {
         }
         #endif
         
-        #if DEBUG
+        #if DEBUG && os(macOS)
         Window("Network Request Debug Window", id: NetworkRequestRecorder.networkRequestDebugID) {
             NetworkRequestDebugView()
                 .environment(networkRecorder)


### PR DESCRIPTION
I made a mistake lol

## Changes Made

- added additional compilation checks for macOS network debugger
- ...
- ...

## Screenshots (if applicable)

## Checklist
- [ ] I have implemented all requirements for this PR and its accompanying issue.
- [ ] I have verified my implementation across all edge cases.
- [ ] I have ensured my changes compile on macOS & iOS.
- [ ] I have resolved all SwiftLint warnings.
