### PR TITLE
Resolve 26.0 Visual Glitches

### DIFF
--- a/CanvasPlusPlayground/Features/Announcements/CourseAnnouncementDetailView.swift
+++ b/CanvasPlusPlayground/Features/Announcements/CourseAnnouncementDetailView.swift
@@ -20,6 +20,7 @@ struct CourseAnnouncementDetailView: View {
             // Workaround to get a clear background in a Form on macOS
             Section { } header: {
                 summarySection
+                    .clipShape(.rect(cornerRadius: 8.0))
                     .multilineTextAlignment(.leading)
             } footer: {
                 Text("")
@@ -89,12 +90,14 @@ private struct SummarySection: View {
         VStack {
             IntelligenceContentView(
                 condition: rippleView,
-                isOutline: announcement.summary != nil
+                isContentProminent: announcement.summary != nil
             ) {
                 VStack(alignment: .leading, spacing: 16) {
                     header
 
                     mainBody
+
+                    Color.clear.frame(height: 24)
                 }
                 .foregroundStyle(
                     announcement.summary == nil ? .white : .primary
@@ -102,30 +105,9 @@ private struct SummarySection: View {
                 .frame(maxWidth: .infinity)
                 .padding(8)
             }
-
-            HStack {
-                Spacer()
-
-                if loadingSummary {
-                    ProgressView()
-                        .controlSize(.small)
-                }
-
-                Group {
-                    Button("Summarize" + (announcement.summary != nil ? " Again" : "")) {
-                        Task {
-                            await summarize()
-                        }
-                    }
-                    .disabled(
-                        loadingSummary || !IntelligenceSupport.isModelAvailable
-                    )
-                }
-                #if os(macOS)
-                // The Button would otherwise be bold since it's in a
-                // Section header
-                .fontWeight(.regular)
-                #endif
+            .overlay(alignment: .bottom) {
+                summarizeButton
+                    .offset(y: -8)
             }
         }
         .animation(.default, value: announcement.summary != nil)
@@ -155,6 +137,35 @@ private struct SummarySection: View {
             Text(description)
                 .font(.caption)
         }
+    }
+
+    private var summarizeButton: some View {
+        HStack {
+            Spacer()
+
+            if loadingSummary {
+                ProgressView()
+                    .controlSize(.small)
+            }
+
+            Group {
+                Button("Summarize" + (announcement.summary != nil ? " Again" : "")) {
+                    Task {
+                        await summarize()
+                    }
+                }
+                .buttonStyle(.glass)
+                .disabled(
+                    loadingSummary || !IntelligenceSupport.isModelAvailable
+                )
+            }
+            #if os(macOS)
+            // The Button would otherwise be bold since it's in a
+            // Section header
+            .fontWeight(.regular)
+            #endif
+        }
+        .padding(.horizontal)
     }
 
     private var description: String {

--- a/CanvasPlusPlayground/Features/Files/FileViewer.swift
+++ b/CanvasPlusPlayground/Features/Files/FileViewer.swift
@@ -23,6 +23,7 @@ struct FileViewer: View {
                 QuickLookPreview(url: url) { dismiss() }
                     #if os(iOS)
                     .ignoresSafeArea()
+                    .toolbar(.hidden)
                     #else
                     .toolbar {
                         ShareLink(item: url)

--- a/CanvasPlusPlayground/Features/Files/FoldersPageView.swift
+++ b/CanvasPlusPlayground/Features/Files/FoldersPageView.swift
@@ -111,16 +111,6 @@ struct FoldersPageView: View {
         FolderRow(folder: subFolder)
     }
 
-    @ViewBuilder
-    func destinationView(for item: Selection) -> some View {
-        switch item {
-        case .file(let file):
-            FileViewer(courseID: course.id, file: file)
-        case .folder(let folder):
-            FoldersPageView(course: course, folder: folder)
-        }
-    }
-
     private func loadContents() async {
         isLoadingContents = true
         if let folder {

--- a/CanvasPlusPlayground/Intelligence/Views/IntelligenceContentView.swift
+++ b/CanvasPlusPlayground/Intelligence/Views/IntelligenceContentView.swift
@@ -11,7 +11,6 @@ import SwiftUI
 @available(macOS 26.0, iOS 26.0, *)
 struct IntelligenceContentView<V: View>: View {
     @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
-    @Namespace private var namespace
 
     /// This view ripples upon change of this condition
     let condition: Bool
@@ -27,7 +26,7 @@ struct IntelligenceContentView<V: View>: View {
     /// A view designated for promoting intelligence features within the app.
     /// - Parameters:
     ///   - condition: This view ripples upon change of this condition.
-    ///   - isOutline: If this boolean is `true`, the background of the view appears more faded, allowing the content to appear more prominent
+    ///   - isContentProminent: If this boolean is `true`, the background of the view appears more faded, allowing the content to appear more prominent
     ///   If `nil` is passed in, `condition` is used instead.
     ///   - content: The view's contents
     init(condition: Bool, isContentProminent: Bool? = nil, @ViewBuilder content: @escaping () -> V) {
@@ -64,7 +63,6 @@ struct IntelligenceContentView<V: View>: View {
                                 colors: IntelligenceSupport.gradientColors
                             )
                 )
-                .matchedGeometryEffect(id: "background", in: namespace)
                 .overlay(
                     isContentProminent ? .ultraThickMaterial : .thinMaterial,
                     in: .rect

--- a/CanvasPlusPlayground/Intelligence/Views/IntelligenceContentView.swift
+++ b/CanvasPlusPlayground/Intelligence/Views/IntelligenceContentView.swift
@@ -15,8 +15,9 @@ struct IntelligenceContentView<V: View>: View {
 
     /// This view ripples upon change of this condition
     let condition: Bool
-    /// This boolean determines whether the background of the view is an outline stroke or is filled.
-    let isOutline: Bool
+    /// If this boolean is `true`, the background of the view appears more faded, allowing the
+    /// content to appear more prominent.
+    let isContentProminent: Bool
     /// The view's contents
     let content: V
 
@@ -26,12 +27,12 @@ struct IntelligenceContentView<V: View>: View {
     /// A view designated for promoting intelligence features within the app.
     /// - Parameters:
     ///   - condition: This view ripples upon change of this condition.
-    ///   - isOutline: This boolean determines whether the background of the view is an outline stroke or is filled.
+    ///   - isOutline: If this boolean is `true`, the background of the view appears more faded, allowing the content to appear more prominent
     ///   If `nil` is passed in, `condition` is used instead.
     ///   - content: The view's contents
-    init(condition: Bool, isOutline: Bool? = nil, @ViewBuilder content: @escaping () -> V) {
+    init(condition: Bool, isContentProminent: Bool? = nil, @ViewBuilder content: @escaping () -> V) {
         self.condition = condition
-        self.isOutline = isOutline ?? condition
+        self.isContentProminent = isContentProminent ?? condition
         self.content = content()
     }
 
@@ -55,28 +56,19 @@ struct IntelligenceContentView<V: View>: View {
         TimelineView(.animation) { _ in
             let elapsedTime = startTime.distance(to: Date.now)
 
-            if !isOutline {
-                RoundedRectangle(cornerRadius: 8.0)
-                    .fill(
-                        reduceTransparency ? .intelligenceGradient() :
-                                .animatedGradient(
-                                    time: elapsedTime,
-                                    colors: IntelligenceSupport.gradientColors
-                                )
-                    )
-                    .matchedGeometryEffect(id: "background", in: namespace)
-                    .overlay(.thinMaterial, in: .rect(cornerRadius: 8.0))
-            } else {
-                RoundedRectangle(cornerRadius: 8.0)
-                    .strokeBorder(
-                        .animatedGradient(
-                            time: elapsedTime,
-                            colors: IntelligenceSupport.gradientColors
-                        ),
-                        lineWidth: 2.0
-                    )
-                    .matchedGeometryEffect(id: "background", in: namespace)
-            }
+            Rectangle()
+                .fill(
+                    reduceTransparency ? .intelligenceGradient() :
+                            .animatedGradient(
+                                time: elapsedTime,
+                                colors: IntelligenceSupport.gradientColors
+                            )
+                )
+                .matchedGeometryEffect(id: "background", in: namespace)
+                .overlay(
+                    isContentProminent ? .ultraThickMaterial : .thinMaterial,
+                    in: .rect
+                )
         }
     }
 }


### PR DESCRIPTION
Fixes #353

## Changes Made

- #365:  Refactor announcement summary section to extend the background below the button overlay. The issue is that iOS 26.0 has a different list row corner radius that exists regardless of the row contents and its background. We have to work around this. Now, when a summary is displayed, the `IntelligenceContentView` makes the background material thicker rather than making it an outline.
- #361 : Hide the original navigation bar so 2 navigation bars aren't shown.

## Screenshots (if applicable)

<img width="400" alt="Simulator Screenshot - iPhone 16 Pro - 2025-09-04 at 15 47 18" src="https://github.com/user-attachments/assets/16c6cfec-5364-4cfa-9d8a-841449820856" />
<img width="400" alt="Simulator Screenshot - iPhone 16 Pro - 2025-09-04 at 15 47 06" src="https://github.com/user-attachments/assets/19310a0e-d19e-46af-8a4f-8fd8b5f6d1d3" />
<img width="400" alt="Simulator Screenshot - iPhone 16 Pro - 2025-09-04 at 15 46 55" src="https://github.com/user-attachments/assets/17024288-10c1-44db-ab40-a8084b0dc61a" />
<img width="400" alt="Simulator Screenshot - iPhone 16 Pro - 2025-09-04 at 15 46 49" src="https://github.com/user-attachments/assets/175f3961-2792-4ece-8d10-9cd2dc9b1a36" />


## Checklist
- [x] I have implemented all requirements for this PR and its accompanying issue.
- [x] I have verified my implementation across all edge cases.
- [x] I have ensured my changes compile on macOS & iOS.
- [x] I have resolved all SwiftLint warnings.
