### PR TITLE
Display External Tools Links

### DIFF
--- a/CanvasPlusPlayground/Features/Courses/CourseView.swift
+++ b/CanvasPlusPlayground/Features/Courses/CourseView.swift
@@ -39,15 +39,37 @@ struct CourseView: View {
         }
     }
 
+    private var externalCoursePageLinks: [CanvasTab] {
+        guard !course.tabs.isEmpty, pickerService == nil else {
+            return []
+        }
+
+        return course.tabs
+            .filter { $0.visibility == .public }
+            .filter { $0.type == .external }
+    }
+
     var body: some View {
         @Bindable var navigationModel = navigationModel
 
-        List(coursePages, id: \.self, selection: $navigationModel.selectedCoursePage) { page in
-            NavigationLink(value: NavigationModel.Destination.coursePage(page, course)) {
-                Label(page.title, systemImage: page.systemImageIcon)
-                    .contextMenu(for: FocusWindowInfo(courseID: course.id, coursePage: page))
+        List(selection: $navigationModel.selectedCoursePage) {
+            Section {
+                ForEach(coursePages, id: \.self) { page in
+                    NavigationLink(value: NavigationModel.Destination.coursePage(page, course)) {
+                        Label(page.title, systemImage: page.systemImageIcon)
+                            .contextMenu(for: FocusWindowInfo(courseID: course.id, coursePage: page))
+                    }
+                    .tag(page)
+                }
             }
-            .tag(page)
+
+            Section("External") {
+                ForEach(externalCoursePageLinks) { link in
+                    Link(destination: link.htmlAbsoluteUrl) {
+                        Label(link.label, systemImage: "link")
+                    }
+                }
+            }
         }
         .onAppear {
             navigationModel.selectedCoursePage = nil


### PR DESCRIPTION
Fixes #374 

## Changes Made

- Create a new section in `CourseView` which displays links to external tools. Ideally these go directly to the site using the `ExternalTool` Canvas model, which we currently don't support.

## Screenshots (if applicable)

<img width="1179" height="797" alt="Screenshot 2025-09-06 at 10 03 42 AM" src="https://github.com/user-attachments/assets/8f52b6db-6662-4b34-9595-e0f9feb3879e" />

## Checklist
- [x] I have implemented all requirements for this PR and its accompanying issue.
- [x] I have verified my implementation across all edge cases.
- [x] I have ensured my changes compile on macOS & iOS.
- [x] I have resolved all SwiftLint warnings.
