### PR TITLE
Move #endif to fix build error

### DIFF
--- a/CanvasPlusPlayground/Features/Debug/NetworkRequestRecorder.swift
+++ b/CanvasPlusPlayground/Features/Debug/NetworkRequestRecorder.swift
@@ -88,8 +88,6 @@ final class NetworkRequestRecorder {
     }
 }
 
-#endif
-
 extension Data {
     fileprivate func jsonToPrettyString() -> String? {
         if let json = try? JSONSerialization.jsonObject(with: self, options: .mutableContainers),
@@ -100,3 +98,5 @@ extension Data {
         }
     }
 }
+
+#endif


### PR DESCRIPTION
Fixes --

## Changes Made

- The RELEASE version fails the build because of the incorrect compiler flag placement.