### PR TITLE
Fixes for the File Viewer Tab Bug and Customize Course View

### DIFF
--- a/CanvasPlusPlayground/Common/Components/CustomizeCourseView.swift
+++ b/CanvasPlusPlayground/Common/Components/CustomizeCourseView.swift
@@ -86,10 +86,10 @@ struct CustomizeCourseView: View {
         return LazyVGrid(columns: columns, spacing: 12) {
             ForEach(Array(colorList.enumerated()), id: \.offset) { _, color in
                 ColorSelectionButton(color: color, isSelected: color == selectedColor) {
-                    if selectedColor == nil {
-                        selectedColor = color
+                    if selectedColor == color {
+                        selectedColor = nil  // tapping a selected button should toggle the color off
                     } else {
-                        selectedColor = nil // tapping a selected button should toggle the color off
+                        selectedColor = color
                     }
                 }
             }
@@ -139,10 +139,10 @@ struct CustomizeCourseView: View {
                                 color: color,
                                 isSelected: selectedColor == color,
                                 onSelect: {
-                                    if selectedColor == nil {
-                                        selectedColor = color
+                                    if selectedColor == color {
+                                        selectedColor = nil  // tapping a selected button should toggle the color off
                                     } else {
-                                        selectedColor = nil // tapping a selected button should toggle the color off
+                                        selectedColor = color
                                     }
 
                                 }

--- a/CanvasPlusPlayground/Features/Files/FileViewer.swift
+++ b/CanvasPlusPlayground/Features/Files/FileViewer.swift
@@ -9,7 +9,8 @@ import SwiftUI
 
 struct FileViewer: View {
     @Environment(\.dismiss) private var dismiss
-
+    @Environment(\.horizontalSizeClass) var horizontalSizeClass
+    
     let courseID: Course.ID
     let file: File
     let fileService = CourseFileService()
@@ -62,7 +63,10 @@ struct FileViewer: View {
         .navigationTitle(file.displayName)
         #if os(iOS)
         .navigationBarBackButtonHidden()
-        .toolbar(.hidden, for: .tabBar)
+        .toolbar(
+                    horizontalSizeClass == .compact ? .hidden : .automatic,
+                    for: .tabBar
+                )
         #endif
     }
 

--- a/CanvasPlusPlayground/Features/Navigation/CustomizeCourseMenu.swift
+++ b/CanvasPlusPlayground/Features/Navigation/CustomizeCourseMenu.swift
@@ -60,17 +60,7 @@ private struct CustomizeCourseMenu: ViewModifier {
                     courseActionsMenu
                     #if os(macOS)
                         .popover(isPresented: $showCourseCustomizer) {
-                            CustomizeCourseView(courseName: course.displayName, selectedSymbol: course.displaySymbol, selectedColor: course.rgbColors?.color, onDismiss: { symbol, color in
-                                DispatchQueue.main.async {
-                                    if let color {
-                                        course.rgbColors = .init(color: color)
-                                    } else {
-                                        course.rgbColors = nil
-                                    }
-
-                                    course.courseSymbol = symbol
-                                }
-                            })
+                            customizeCourseView
                         }
                     #endif
                 }
@@ -88,19 +78,23 @@ private struct CustomizeCourseMenu: ViewModifier {
             }
             #if os(iOS)
             .sheet(isPresented: $showCourseCustomizer) {
-                CustomizeCourseView(courseName: course.displayName, selectedSymbol: course.displaySymbol, selectedColor: course.rgbColors?.color, onDismiss: { symbol, color in
-                    DispatchQueue.main.async {
-                        if let color {
-                            course.rgbColors = .init(color: color)
-                        } else {
-                            course.rgbColors = nil
-                        }
-
-                        course.courseSymbol = symbol
-                    }
-                })
+                customizeCourseView
             }
             #endif
+    }
+
+    private var customizeCourseView: some View {
+        CustomizeCourseView(courseName: course.displayName, selectedSymbol: course.displaySymbol, selectedColor: course.rgbColors?.color, onDismiss: { symbol, color in
+            DispatchQueue.main.async {
+                if let color {
+                    course.rgbColors = .init(color: color)
+                } else {
+                    course.rgbColors = nil
+                }
+
+                course.courseSymbol = symbol
+            }
+        })
     }
 
     private var favCourseButton: some View {


### PR DESCRIPTION
Fixes #452 #453

## Changes Made

- Added a view modifier to hide tab bar on iOS when File Viewer is open
- Modified customize course view to require color selection before confirmation
- ...

## Screenshots (if applicable)

https://github.com/user-attachments/assets/441376c2-acf2-4957-b803-3b7a7fb84c86

![Screen Recording 2025-10-13 at 7 41 29 AM](https://github.com/user-attachments/assets/db01a61c-e727-4350-8a8e-8718ceb4b27b)


## Checklist
- [ ] I have implemented all requirements for this PR and its accompanying issue.
- [ ] I have verified my implementation across all edge cases.
- [ ] I have ensured my changes compile on macOS & iOS.
- [ ] I have resolved all SwiftLint warnings.
