### PR TITLE
[Modules] Fix page running in the background

### DIFF
--- a/CanvasPlusPlayground/Common/Components/HTMLView.swift
+++ b/CanvasPlusPlayground/Common/Components/HTMLView.swift
@@ -33,9 +33,17 @@ struct HTMLView: ViewRepresentable {
     func updateUIView(_ uiView: WKWebView, context: Context) {
         updateView(uiView, context: context)
     }
+
+    static func dismantleUIView(_ uiView: WKWebView, coordinator: Coordinator) {
+        dismantleView(uiView)
+    }
     #else
     func updateNSView(_ nsView: WKWebView, context: Context) {
         updateView(nsView, context: context)
+    }
+
+    static func dismantleNSView(_ nsView: WKWebView, coordinator: Coordinator) {
+        dismantleView(nsView)
     }
     #endif
 
@@ -53,6 +61,13 @@ struct HTMLView: ViewRepresentable {
 
     func updateView(_ view: WKWebView, context: Context) {
         view.loadHTMLString(html, baseURL: nil)
+    }
+
+    static func dismantleView(_ view: WKWebView) {
+        view.stopLoading()
+        view.navigationDelegate = nil
+
+        view.loadHTMLString("", baseURL: nil)
     }
 
     class Coordinator: NSObject, WKNavigationDelegate {


### PR DESCRIPTION
Fixes #455 

## Changes Made

- Ensure the webview is cleared out and does not reference the page when dismantled.

## Screenshots (if applicable)

## Checklist
- [x] I have implemented all requirements for this PR and its accompanying issue.
- [x] I have verified my implementation across all edge cases.
- [x] I have ensured my changes compile on macOS & iOS.
- [x] I have resolved all SwiftLint warnings.
