### PR TITLE
[Widgets] Implement on-demand widget refresh

### DIFF
--- a/CanvasPlusPlayground/Features/Announcements/AllAnnouncementsManager.swift
+++ b/CanvasPlusPlayground/Features/Announcements/AllAnnouncementsManager.swift
@@ -55,7 +55,6 @@ import Combine
         set { }
     }
     var fetchStatus: WidgetFetchStatus = .loading
-    var refreshTrigger = PassthroughSubject<Void, Never>()
 
     func fetchAnnouncements(courses: [Course]) async {
         guard !courses.isEmpty else { return }

--- a/CanvasPlusPlayground/Features/Courses/CourseManager.swift
+++ b/CanvasPlusPlayground/Features/Courses/CourseManager.swift
@@ -37,13 +37,21 @@ class CourseManager {
                 pageConfiguration: .all(perPage: 40)
             )
 
-            self.activeCourses = try await courseService.getCourses(
+            WidgetContext.shared.requestToRefreshAllWidgets()
+
+            let latestCourses = try await courseService.getCourses(
                 enrollmentType: nil,
                 enrollmentState: .active,
                 excludeBlueprintCourses: false,
                 state: [],
                 pageConfiguration: .all(perPage: 40)
             )
+
+            if latestCourses != self.activeCourses {
+                self.activeCourses = latestCourses
+                WidgetContext.shared.requestToRefreshAllWidgets()
+            }
+
             LoggerService.main.debug("Fetched courses: \(self.activeCourses.compactMap(\.name))")
         } catch {
             LoggerService.main.error("Failed to fetch courses. \(error)")

--- a/CanvasPlusPlayground/Features/Dashboard/Support/ExampleListWidget.swift
+++ b/CanvasPlusPlayground/Features/Dashboard/Support/ExampleListWidget.swift
@@ -24,7 +24,6 @@ fileprivate struct ExampleListWidget: @MainActor ListWidget {
 @Observable
 private class StepsDataSource: ListWidgetDataSource {
     var fetchStatus: WidgetFetchStatus = .loading
-    var refreshTrigger = PassthroughSubject<Void, Never>()
     var widgetData: [ListWidgetData] = []
 
     func fetchData(context: WidgetContext) async throws {

--- a/CanvasPlusPlayground/Features/Recent Items/RecentItemsManager.swift
+++ b/CanvasPlusPlayground/Features/Recent Items/RecentItemsManager.swift
@@ -48,7 +48,6 @@ class RecentItemsManager: ListWidgetDataSource {
     }
 
     var fetchStatus: WidgetFetchStatus = .loading
-    var refreshTrigger = PassthroughSubject<Void, Never>()
 
     init() {
         let savedMax = UserDefaults.standard.integer(forKey: Self.maxRecentItemsKey)
@@ -56,7 +55,7 @@ class RecentItemsManager: ListWidgetDataSource {
         getRecentItems()
     }
 
-    func logRecentItem(
+    @MainActor func logRecentItem(
         itemID: String,
         courseID: String,
         type: RecentItemType
@@ -83,12 +82,15 @@ class RecentItemsManager: ListWidgetDataSource {
             trimRecentItemsIfNeeded()
         }
 
-        refreshTrigger.send()
+        WidgetContext.shared
+            .requestToRefreshWidget(widget: RecentItemsWidget.self)
     }
 
-    func clearAllRecentItems() {
+    @MainActor func clearAllRecentItems() {
         recentItems.removeAll()
-        refreshTrigger.send()
+
+        WidgetContext.shared
+            .requestToRefreshWidget(widget: RecentItemsWidget.self)
     }
 
     private func trimRecentItemsIfNeeded() {

--- a/CanvasPlusPlayground/Features/ToDoItems/ToDoListManager.swift
+++ b/CanvasPlusPlayground/Features/ToDoItems/ToDoListManager.swift
@@ -19,7 +19,6 @@ class ToDoListManager: ListWidgetDataSource, BigNumberWidgetDataSource {
 
     // ListWidgetDataSource
     var fetchStatus: WidgetFetchStatus = .loading
-    var refreshTrigger = PassthroughSubject<Void, Never>()
     var widgetData: [ListWidgetData] {
         get {
             displayedToDoItems.map {


### PR DESCRIPTION
Fixes --

## Changes Made

- As a part of #451, there was an issue where widgets would not refresh when onboarding was complete. As a part of this PR, data sources now do not require a `refreshTrigger`. Instead, this is part of the global `shared` instance of `WidgetContext`, allowing any data source to refresh widgets on-demand using `requestToRefreshAllWidgets` or `requestToRefreshWidget(widget:)`.
- This is called when `CourseManager` fetches the latest courses, fixing the earlier bug.
- We should also implement this in other data sources (like announcements and todos), will do as part of another PR.

## Screenshots (if applicable)

## Checklist
- [x] I have implemented all requirements for this PR and its accompanying issue.
- [x] I have verified my implementation across all edge cases.
- [x] I have ensured my changes compile on macOS & iOS.
- [x] I have resolved all SwiftLint warnings.
