### PR TITLE
Revise Announcement Web View Fonts

### DIFF
--- a/CanvasPlusPlayground/Features/Announcements/HTMLWebViewWrapper.swift
+++ b/CanvasPlusPlayground/Features/Announcements/HTMLWebViewWrapper.swift
@@ -101,12 +101,14 @@ private struct HTMLWebView: PlatformRepresentable {
                     body {
                         color: #fff;
                         background: transparent !important;
+                        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Arial, sans-serif;
                     }
                 }
                 @media (prefers-color-scheme: light) {
                     body {
                         color: #000;
                         background: transparent !important;
+                        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Arial, sans-serif;
                     }
                 }
             </style>
@@ -127,12 +129,14 @@ private struct HTMLWebView: PlatformRepresentable {
                 body {
                     color: #fff;
                     background: transparent !important;
+                    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Arial, sans-serif;
                 }
             }
             @media (prefers-color-scheme: light) {
                 body {
                     color: #000;
                     background: transparent !important;
+                    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Arial, sans-serif;
                 }
             }
     </style>


### PR DESCRIPTION
Fixes #459 

## Changes Made
- added custom css to for web view fonts

## Screenshots (if applicable)
<img width="1356" height="858" alt="Screenshot 2025-10-15 at 6 14 11 PM" src="https://github.com/user-attachments/assets/a006f805-8772-4025-844e-0e24ec1d6b57" />
<img width="564" height="1062" alt="Screenshot 2025-10-15 at 6 13 36 PM" src="https://github.com/user-attachments/assets/98ecaac0-a96a-411e-90e6-8d1eade565ca" />

## Checklist
- [x] I have implemented all requirements for this PR and its accompanying issue.
- [x] I have verified my implementation across all edge cases.
- [x] I have ensured my changes compile on macOS & iOS.
- [x] I have resolved all SwiftLint warnings.
