### PR TITLE
Added refreshable modifier to Modules view to match other list views

### DIFF
--- a/CanvasPlusPlayground/Features/Modules/ModulesListView.swift
+++ b/CanvasPlusPlayground/Features/Modules/ModulesListView.swift
@@ -40,6 +40,9 @@ struct ModulesListView: View {
         .statusToolbarItem("Modules", isVisible: isLoadingModules)
         .environment(modulesVM)
         .navigationTitle("Modules")
+        .refreshable {
+            await modulesVM.fetchModules()
+        }
     }
 
     func handleModuleSelection() async {


### PR DESCRIPTION
Fixes #466 
## Changes Made

- Added refreshable modifier to Modules view to match other list views

## Screenshots (if applicable)

## Checklist
- [x] I have implemented all requirements for this PR and its accompanying issue.
- [x] I have verified my implementation across all edge cases.
- [x] I have ensured my changes compile on macOS & iOS.
- [x] I have resolved all SwiftLint warnings.
