### PR TITLE
Fixed course groups view with weird shadow

### DIFF
--- a/CanvasPlusPlayground/Features/Groups/CourseGroups/CourseGroupsView.swift
+++ b/CanvasPlusPlayground/Features/Groups/CourseGroups/CourseGroupsView.swift
@@ -19,28 +19,24 @@ struct CourseGroupsView: View {
     }
 
     var body: some View {
-        GroupsListView()
-            .task {
-                isLoading = true
-                await courseGroupsVM.fetchGroups(for: course.id)
-                isLoading = false
+        Group {
+            if isLoading == false && courseGroupsVM.groups.isEmpty {
+                ContentUnavailableView("No groups for this course could be found.", systemImage: "person.2.slash.fill")
+            } else {
+                GroupsListView()
+                    .searchable(
+                        text: $courseGroupsVM.searchText,
+                        prompt: "Search Groups..."
+                    )
             }
-            .statusToolbarItem("Groups", isVisible: isLoading)
-            .environment(courseGroupsVM)
-            #if os(iOS)
-            .searchable(
-                text: $courseGroupsVM.searchText,
-                placement:
-                        .navigationBarDrawer(
-                            displayMode: .always
-                        ),
-                prompt: "Search Groups..."
-            )
-            #else
-            .searchable(
-                text: $courseGroupsVM.searchText,
-                prompt: "Search Groups..."
-            )
-            #endif
+        }
+
+        .task {
+            isLoading = true
+            await courseGroupsVM.fetchGroups(for: course.id)
+            isLoading = false
+        }
+        .statusToolbarItem("Groups", isVisible: isLoading)
+        .environment(courseGroupsVM)
     }
 }


### PR DESCRIPTION
Fixes #467 

## Changes Made

- Added a `ContentUnavailableView` when a course has no groups

## Screenshots (if applicable)
Before
<img width="564" height="1062" alt="Image" src="https://github.com/user-attachments/assets/dcb34fa5-3771-4548-a8e6-6243551bb08d" />
After
<img width="564" height="1062" alt="Screenshot 2025-10-18 at 3 46 23 PM" src="https://github.com/user-attachments/assets/1a73a4d8-f18e-4074-8669-6473eb7c4543" />
<img width="1436" height="1028" alt="Screenshot 2025-10-18 at 3 48 21 PM" src="https://github.com/user-attachments/assets/2c024a60-db88-4a94-b875-ed2cd08597a8" />


## Checklist
- [x] I have implemented all requirements for this PR and its accompanying issue.
- [x] I have verified my implementation across all edge cases.
- [x] I have ensured my changes compile on macOS & iOS.
- [x] I have resolved all SwiftLint warnings.
