### PR TITLE
Fixed issue where loading indicator was obstructed by tab bar

### DIFF
--- a/CanvasPlusPlayground/Common/Components/StatusToolbarItem.swift
+++ b/CanvasPlusPlayground/Common/Components/StatusToolbarItem.swift
@@ -23,6 +23,7 @@ private struct StatusToolbarItem: ViewModifier {
                     toolbarContent
                         .padding(6)
                         .background(.thinMaterial, in: .rect(cornerRadius: 8))
+                        .compatibleGlassEffect()
                         .padding(.bottom)
                 }
             }


### PR DESCRIPTION
Fixes #469 

## Changes Made

- Modified `StatusToolbarItem` to just use `.overlay` for both iOS and macOS

## Screenshots (if applicable)
![Screen Recording 2025-10-18 at 3 58 14 PM](https://github.com/user-attachments/assets/280ca2f9-1644-475f-a6cf-69fa7fa9c6bd)

## Checklist
- [x] I have implemented all requirements for this PR and its accompanying issue.
- [x] I have verified my implementation across all edge cases.
- [x] I have ensured my changes compile on macOS & iOS.
- [x] I have resolved all SwiftLint warnings.
