### PR TITLE
Hot Fix: Ignore todo item cache and remove model references

### DIFF
--- a/CanvasPlusPlayground/Features/People/PeopleManager.swift
+++ b/CanvasPlusPlayground/Features/People/PeopleManager.swift
@@ -92,7 +92,9 @@ class PeopleManager: SearchResultListDataSource {
 
             if queryMode == .live && page == 1 {
                 setQueryMode(.offline)
-                try await fetchPeople()
+                setLoadingState(.idle)
+                // FIXME: Crashes on RELEASE configuration
+                // try await fetchPeople()
             } else {
                 throw error
             }

--- a/CanvasPlusPlayground/Features/ToDoItems/ToDoListView.swift
+++ b/CanvasPlusPlayground/Features/ToDoItems/ToDoListView.swift
@@ -54,7 +54,19 @@ struct ToDoListView: View {
             await loadItems()
         }
         .overlay {
-            if displayedResults.isEmpty {
+            if let errorMessage = listManager.errorMessage {
+                ContentUnavailableView {
+                    Label("Unable to Load To-Do Items", systemImage: "exclamationmark.triangle")
+                } description: {
+                    Text(errorMessage)
+                } actions: {
+                    Button("Try Again") {
+                        Task {
+                            await loadItems()
+                        }
+                    }
+                }
+            } else if displayedResults.isEmpty && !isLoading {
                 ContentUnavailableView("No To-Do Items", systemImage: "checklist.checked")
             }
         }


### PR DESCRIPTION
Fixes --

## Changes Made

- `ToDoItem` had references to `Assignment` and `Quiz`. Remove these as they caused crashes.
- Remove usage of cache for todo list manager.
- `PeopleManager` would crash on `RELEASE` configurations when offline (although it would run into this even otherwise). Remove the call again to fetchData for now

## Screenshots (if applicable)

## Checklist
- [x] I have implemented all requirements for this PR and its accompanying issue.
- [x] I have verified my implementation across all edge cases.
- [x] I have ensured my changes compile on macOS & iOS.
- [x] I have resolved all SwiftLint warnings.
