### PR TITLE
Dashboard: Move capsule navigation bar to scroll view

### DIFF
--- a/CanvasPlusPlayground/Features/Dashboard/DashboardView.swift
+++ b/CanvasPlusPlayground/Features/Dashboard/DashboardView.swift
@@ -21,6 +21,8 @@ struct DashboardView: View {
 
     var body: some View {
         ScrollView {
+            NavigationBanner()
+
             Dashboard(
                 maxSmallWidgetWidth: maxSmallWidgetWidth,
                 maxMediumWidgetWidth: maxMediumWidgetWidth,
@@ -98,9 +100,6 @@ struct DashboardView: View {
             #if os(macOS)
             .frame(width: 300, height: 300)
             #endif
-        }
-        .safeAreaInset(edge: .top) {
-            NavigationBanner()
         }
         .defaultNavigationDestination()
     }


### PR DESCRIPTION
Fixes #488 

## Changes Made

- Moves the horizontal capsule menu into the scroll view so it's not persistent or behind the nav title when scrolling

## Screenshots (if applicable)

## Checklist
- [x] I have implemented all requirements for this PR and its accompanying issue.
- [x] I have verified my implementation across all edge cases.
- [x] I have ensured my changes compile on macOS & iOS.
- [x] I have resolved all SwiftLint warnings.
